### PR TITLE
Updated backend for staticpage plugin

### DIFF
--- a/serendipity_event_staticpage/UTF-8/lang_de.inc.php
+++ b/serendipity_event_staticpage/UTF-8/lang_de.inc.php
@@ -36,6 +36,7 @@
 @define('PLUGIN_STATICPAGELIST_FRONTPAGE_DESC',     'Einen Link zur Startseite erstellen');
 @define('PLUGIN_STATICPAGELIST_FRONTPAGE_LINKNAME', 'Startseite');
 
+@define('STATICPAGE_LIST_EXISTING_PAGES',           'Liste vorhandener statischer Seiten');
 @define('STATICPAGE_HEADLINE',                      'Kopfzeile');
 @define('STATICPAGE_HEADLINE_BLAHBLAH',             'Zeigt eine Kopfzeile als Titel der statischen Seite an');
 @define('STATICPAGE_TITLE',                         'Statische Seiten');

--- a/serendipity_event_staticpage/lang_de.inc.php
+++ b/serendipity_event_staticpage/lang_de.inc.php
@@ -36,6 +36,7 @@
 @define('PLUGIN_STATICPAGELIST_FRONTPAGE_DESC',     'Einen Link zur Startseite erstellen');
 @define('PLUGIN_STATICPAGELIST_FRONTPAGE_LINKNAME', 'Startseite');
 
+@define('STATICPAGE_LIST_EXISTING_PAGES',           'Liste vorhandener statischer Seiten');
 @define('STATICPAGE_HEADLINE',                      'Kopfzeile');
 @define('STATICPAGE_HEADLINE_BLAHBLAH',             'Zeigt eine Kopfzeile als Titel der statischen Seite an');
 @define('STATICPAGE_TITLE',                         'Statische Seiten');

--- a/serendipity_event_staticpage/lang_en.inc.php
+++ b/serendipity_event_staticpage/lang_en.inc.php
@@ -9,6 +9,7 @@
 //
 //  serendipity_event_staticpage.php
 //
+@define('STATICPAGE_LIST_EXISTING_PAGES', 'List of existing static pages');
 @define('STATICPAGE_HEADLINE', 'Headline');
 @define('STATICPAGE_HEADLINE_BLAHBLAH', 'Shows a headline above the content which is rendered as every other headline in your blog');
 @define('STATICPAGE_TITLE', 'Static Pages');


### PR DESCRIPTION
1. Functionality remains mainly unchanged. Only preview display has been changed
   from subpage-based access to id-based access, because subpage can be ambigous. The
   new feature required changes to selected().
2. A hook-in is provided the generate a overview of all static pages when not editing
   a static page. This makes the overview page more pleasent for users. The functionality
   of the header remains unchanged. Only a list of pages is generated below the header.
   The style of this list is taken from entry listing to create a consistent look and feel
   for users.
   @garvinhicking: The code simply hooks into existing code without changing its functionality.
   The intention was to add a more pleasent overview to staticpage while remaining its workflow.
   The code for generating this list was taken from s9y core and was modified to the needs of 
   staticpage. I asked for pulling this change, because it makes staticpage more attrative at first
   view and makes navigation easier and more pleasent.
