### PR TITLE
Added option "stripBrs" ("Ignore <br> tags")

### DIFF
--- a/serendipity_event_dpsyntaxhighlighter/lang_en.inc.php
+++ b/serendipity_event_dpsyntaxhighlighter/lang_en.inc.php
@@ -29,3 +29,5 @@
 @define('PLUGIN_EVENT_DPSYNTAXHIGHLIGHTER_SMARTTABS_DESC', 'Allows you to turn smart tabs feature on and off.');
 @define('PLUGIN_EVENT_DPSYNTAXHIGHLIGHTER_TABSIZE', 'Tab size for smart tabs');
 @define('PLUGIN_EVENT_DPSYNTAXHIGHLIGHTER_TABSIZE_DESC', 'Allows you to adjust tab size.');
+@define('PLUGIN_EVENT_DPSYNTAXHIGHLIGHTER_STRIPBRS', 'Ignore <br> tags');
+@define('PLUGIN_EVENT_DPSYNTAXHIGHLIGHTER_STRIPBRS_DESC', 'If your software adds <br /> tags at the end of each line, this option allows you to ignore those..');

--- a/serendipity_event_dpsyntaxhighlighter/serendipity_event_dpsyntaxhighlighter.php
+++ b/serendipity_event_dpsyntaxhighlighter/serendipity_event_dpsyntaxhighlighter.php
@@ -66,6 +66,7 @@ class serendipity_event_dpsyntaxhighlighter extends serendipity_event {
         $conf_array[] = 'gutter';
         $conf_array[] = 'smart-tabs';
         $conf_array[] = 'tab-size';
+        $conf_array[] = 'stripBrs';
         $propbag->add('configuration', $conf_array);
     }
 
@@ -137,6 +138,12 @@ class serendipity_event_dpsyntaxhighlighter extends serendipity_event {
                 $propbag->add('default',        '4');
                 $propbag->add('validate',       'number');
                 break;
+            case 'stripBrs':
+                $propbag->add('type',           'boolean');
+                $propbag->add('name',           PLUGIN_EVENT_DPSYNTAXHIGHLIGHTER_STRIPBRS);
+                $propbag->add('description',    PLUGIN_EVENT_DPSYNTAXHIGHLIGHTER_STRIPBRS_DESC);
+                $propbag->add('default',        'false');
+                break;
         }
         return true;
     }
@@ -172,6 +179,11 @@ class serendipity_event_dpsyntaxhighlighter extends serendipity_event {
 	    }
 	    $footer_add .= '<script type="text/javascript">
   SyntaxHighlighter.config.clipboardSwf = \''.$pluginDir.'/sh/'.$this->version.'/scripts/clipboard.swf\';';
+            
+            $stripBrs = $this->get_config('stripBrs');
+            if ($stripBrs) {
+                $footer_add .=  'SyntaxHighlighter.config.stripBrs = true;';
+            }
             
             $toolbar = $this->get_config('toolbar');
             if (!$toolbar) {


### PR DESCRIPTION
Sorry, only tested it with one-line code snippets. When using multi-line code snippets, my s9y Installation added &lt;br&gt; tags after each line which the plugin showed as &lt;br&gt; (literally) in the blog entry.
So I added the option "stripBrs" which can be enabled to ignore these tags.

Because I have only one s9y Installation, I'm not brave enough to enable this option as default ;)
