### PR TITLE
Update serendipity_event_recaptcha.php

### DIFF
--- a/serendipity_event_recaptcha/serendipity_event_recaptcha.php
+++ b/serendipity_event_recaptcha/serendipity_event_recaptcha.php
@@ -279,7 +279,11 @@ var $error=null;
                         $resp    = null;
                         $theme   = $this->get_config('recaptcha_style', 'red');
                         echo "\n<script type=\"text/javascript\">\n var RecaptchaOptions = { theme : '".$theme."', lang : '" . $serendipity['lang'] . "' };\n</script>";
-                        echo recaptcha_get_html($pubkey, $this->error);
+                        $use_ssl = false;
+                        if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') {
+                            $use_ssl = true;
+                        }
+                        echo recaptcha_get_html($pubkey, $this->error, $use_ssl);
                     }
 
                     return true;


### PR DESCRIPTION
Try to auto-detect if site is served via HTTPS or HTTP. The original version requests the captcha via HTTP. So if the site is served via HTTPS, the browser will block this attempt and no captcha will be shown on the site.

It is not a perfect solution (a better one would be to let the user configure it), since it would not detect the correct value if the webserver is behind a proxy (the proxy serves the site via HTTPS and the webserver via HTTP to the proxy). But this solution will work in most of the cases until a serendipity developer can add an extra configuration option.