### PR TITLE
s9_event_social: Set og:description from s9y_event_metadesc.

### DIFF
--- a/serendipity_event_social/serendipity_event_social.php
+++ b/serendipity_event_social/serendipity_event_social.php
@@ -154,6 +154,7 @@ class serendipity_event_social extends serendipity_event {
                                                                  # /\s+/: multiple newline and whitespaces
                             $meta_description = trim(preg_replace('/\s+/', ' ', substr(strip_tags($entry['body']), 0, 200))) . '...';
                         }
+                        $meta_description = (function_exists('serendipity_specialchars') ? serendipity_specialchars($meta_description) : htmlspecialchars($meta_description, ENT_COMPAT, LANG_CHARSET));
                         echo '<meta property="og:description" content="' . $meta_description . '" />' . "\n";
                         echo '<meta property="og:type" content="article" />' . "\n";
                         echo '<meta property="og:site_name" content="' . $serendipity['blogTitle'] . '" />' . "\n";

--- a/serendipity_event_social/serendipity_event_social.php
+++ b/serendipity_event_social/serendipity_event_social.php
@@ -148,8 +148,13 @@ class serendipity_event_social extends serendipity_event {
                         echo '<!--serendipity_event_shariff-->' . "\n";
                         echo '<meta name="twitter:card" content="summary" />' . "\n";
                         echo '<meta property="og:title" content="' . serendipity_specialchars($entry['title']) . '" />' . "\n";
-                                                                                        # /\s+/: multiple newline and whitespaces
-                        echo '<meta property="og:description" content="' . trim(preg_replace('/\s+/', ' ', substr(strip_tags($entry['body']), 0, 200))) . '..." />' . "\n";
+                        # get desciption from serendipity_event_metadesc, if set; take first 200 chars from body otherwise
+                        $meta_description = $GLOBALS['entry'][0]['properties']['meta_description'];
+                        if (empty($meta_description)) {
+                                                                 # /\s+/: multiple newline and whitespaces
+                            $meta_description = trim(preg_replace('/\s+/', ' ', substr(strip_tags($entry['body']), 0, 200))) . '...';
+                        }
+                        echo '<meta property="og:description" content="' . $meta_description . '" />' . "\n";
                         echo '<meta property="og:type" content="article" />' . "\n";
                         echo '<meta property="og:site_name" content="' . $serendipity['blogTitle'] . '" />' . "\n";
                         echo '<meta property="og:url" content="'. $blogURL . serendipity_specialchars($_SERVER['REQUEST_URI']) . '" />' . "\n";


### PR DESCRIPTION
Currently s9y_event_social is using the first 200 chars of the entry body for the "og:description" meta tag.

The plugin s9y_event_metadesc makes it possible to specify a description for every entry that is used to set the "description" meta tag.  This description, if present, should be used for the "og:description" meta tag, too. Using the first 200 chars can remain as a fallback solution.

At least the description from s9y_event_metadesc needs to be HTML-escaped. I think that goes for the first 200 chars from the body, too.

See http://board.s9y.org/viewtopic.php?f=10&t=20762&start=75 for a discussion (in German).