### PR TITLE
Escape special chars in description.

### DIFF
--- a/serendipity_event_social/serendipity_event_social.php
+++ b/serendipity_event_social/serendipity_event_social.php
@@ -154,6 +154,7 @@ class serendipity_event_social extends serendipity_event {
                                                                  # /\s+/: multiple newline and whitespaces
                             $meta_description = trim(preg_replace('/\s+/', ' ', substr(strip_tags($entry['body']), 0, 200))) . '...';
                         }
+                        $meta_description = serendipity_specialchars($meta_description);
                         echo '<meta property="og:description" content="' . $meta_description . '" />' . "\n";
                         echo '<meta property="og:type" content="article" />' . "\n";
                         echo '<meta property="og:site_name" content="' . $serendipity['blogTitle'] . '" />' . "\n";


### PR DESCRIPTION
Quotes in a manually supplied description - or the first
200 characters of the entry body - have to be escaped
before the text can become the content attribute of
the og:description meta tag.

It doesn't hurt to escape everything, then.

Signed-off-by: Thomas Hochstein <thh@inter.net>