### PR TITLE
Fix kind of copy-paste-error.

### DIFF
--- a/serendipity_event_metadesc/ChangeLog
+++ b/serendipity_event_metadesc/ChangeLog
@@ -1,3 +1,7 @@
+0.15.3:
+-------
+  * Fixed access to $entry some more. :)
+
 0.15.2:
 -------
   * Fixed acces to $entry, thanks to Ian

--- a/serendipity_event_metadesc/serendipity_event_metadesc.php
+++ b/serendipity_event_metadesc/serendipity_event_metadesc.php
@@ -25,7 +25,7 @@ class serendipity_event_metadesc extends serendipity_event {
         $propbag->add('description',   PLUGIN_METADESC_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Garvin Hicking, Judebert, Don Chambers');
-        $propbag->add('version',       '0.15.2');
+        $propbag->add('version',       '0.15.3');
         $propbag->add('requirements',  array(
             'serendipity' => '0.8',
             'php'         => '4.1.0'
@@ -173,7 +173,7 @@ class serendipity_event_metadesc extends serendipity_event {
 
                         $meta_description = $entry['properties']['meta_description'];
                         if (empty($meta_description)) {
-                            $description_body = $entry[0]['body'];
+                            $description_body = $entry['body'];
                             if (isset($entry['plaintext_body'])) {
                                 $description_body = trim($entry['plaintext_body']);
                             }


### PR DESCRIPTION
fc87b5f6d700945fd06836dd2433d80c43984a18 has changed
the way the "body" content was accessed from
   $GLOBALS['entry'][0]
to
   $entry,
but didn't drop the "[0]" everywhere.

Signed-off-by: Thomas Hochstein <thh@inter.net>