### PR TITLE
Update recaptcha URLs

### DIFF
--- a/serendipity_event_recaptcha/UTF-8/lang_cs.inc.php
+++ b/serendipity_event_recaptcha/UTF-8/lang_cs.inc.php
@@ -15,16 +15,16 @@
 
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA', 'Použít kryptogramy Recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Pokud je nastaveno, budou použity kryptogramy Recaptcha. To je speciální druh kryptogramů, který pomáhá při digitalizaci knih. Viz http://www.recaptcha.net. Uživatel si může vybrat, že místo zadávání zobrazených písmen mu bude přehrána krátká zpráva obsahující čísla, která slouží jako kód. Pokud nejsou generovány žádné kryptogramy, server je pravděpodobně mimo službu.');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Pokud je nastaveno, budou použity kryptogramy Recaptcha. To je speciální druh kryptogramů, který pomáhá při digitalizaci knih. Viz https://www.google.com/recaptcha/. Uživatel si může vybrat, že místo zadávání zobrazených písmen mu bude přehrána krátká zpráva obsahující čísla, která slouží jako kód. Pokud nejsou generovány žádné kryptogramy, server je pravděpodobně mimo službu.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE', 'Který typ kryptogramů použít?');
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE_DESC', 'Vyberte jeden z následujících typů: red (červený), white (bílý), blackglass (černé sklo). Tato volba funguje pouze s povoleným javascriptem.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB', 'Veřejný klíč pro kryptogramy Recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Zadejte veřejnou (public) část klíče pro komunikaci se serveren recaptcha.net. O vygenerování páru klíče (veřejný + soukromý klíč) můžete požádat na http://www.recaptcha.net/api/getkey');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Zadejte veřejnou (public) část klíče pro komunikaci se serveren recaptcha.net. O vygenerování páru klíče (veřejný + soukromý klíč) můžete požádat na https://www.google.com/recaptcha/admin');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV', 'Soukromý klíč recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Zadejte soukromou (private) část klíče pro komunikaci se serveren recaptcha.net. O vygenerování páru klíče (veřejný + soukromý klíč) můžete požádat na http://www.recaptcha.net/api/getkey');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Zadejte soukromou (private) část klíče pro komunikaci se serveren recaptcha.net. O vygenerování páru klíče (veřejný + soukromý klíč) můžete požádat na https://www.google.com/recaptcha/admin');
 
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL', 'Vynutit kryptogramy po uplynutí kolika dní?');
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL_DESC', 'Použití kryptogramů může být vynuceno v závislosti na stáří článků. Zadejte počet dní, po jejichž uplynutí od vydání článku je třeba zadat kryptogram. Hodnota 0 znamená, že kryptogramy budou použity vždy.');
@@ -42,5 +42,5 @@
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_CAPTCHAS', 'Nezadal(a) jsi správný řetězec podle antispamového obrázku. Podívej se na kryptogram prosím ještě jednou a zadej správné hodnoty.');
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_RECAPTCHA', 'Nezadali jste veřejný/soukromý klíč v nastavení kryptogramů recaptcha. Kryptogramy budou vypnuty. Pokud je chcete používat, zadejte prosím oba dva klíče v nastavení pluginu Recaptcha, nebo použijte obyčejné kryptogramy (plugin "antispamové metody").');
 
-@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Recaptcha je zvláštní druh <a href="http://en.wikipedia.com/wiki/Captcha">kryptogramu</a>. Uživatel musí rozpoznat dvě slova. První systémem výzva-odpověď (ochrana před spamem), a druhé, které pomáhá při digitalizaci knih. Navíc zrakově postižení lidé mohou použít audio-kryptogram. Pro více informací se podívejte na stránku <a href="http://www.recaptcha.net">www.recaptcha.net</a>.<br/>Pamatujte, že abyste mohli používat tento plugin, musíte se registrovat na zmíněné webové stránce.O klíč můžete požádat  <a href="http://www.recaptcha.net/api/getkey?app=serendipity&domain=');
+@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Recaptcha je zvláštní druh <a href="http://en.wikipedia.com/wiki/Captcha">kryptogramu</a>. Uživatel musí rozpoznat dvě slova. První systémem výzva-odpověď (ochrana před spamem), a druhé, které pomáhá při digitalizaci knih. Navíc zrakově postižení lidé mohou použít audio-kryptogram. Pro více informací se podívejte na stránku <a href="https://www.google.com/recaptcha/">https://www.google.com/recaptcha/</a>.<br/>Pamatujte, že abyste mohli používat tento plugin, musíte se registrovat na zmíněné webové stránce.O klíč můžete požádat  <a href="https://www.google.com/recaptcha/admin');
 @define('PLUGIN_EVENT_RECAPTCHA_INFO2', '">tady</a>. <br/> Pamatujte také prosím, že tento plugin se bude při každém komentáři dotazovat serveru recaptcha, a může proto zpomalit načítání stránek. Pokud bude server recaptcha vypnutý, pak nebudou použity žádné kryptogramy.');

--- a/serendipity_event_recaptcha/UTF-8/lang_cz.inc.php
+++ b/serendipity_event_recaptcha/UTF-8/lang_cz.inc.php
@@ -15,16 +15,16 @@
 
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA', 'Použít kryptogramy Recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Pokud je nastaveno, budou použity kryptogramy Recaptcha. To je speciální druh kryptogramů, který pomáhá při digitalizaci knih. Viz http://www.recaptcha.net. Uživatel si může vybrat, že místo zadávání zobrazených písmen mu bude přehrána krátká zpráva obsahující čísla, která slouží jako kód. Pokud nejsou generovány žádné kryptogramy, server je pravděpodobně mimo službu.');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Pokud je nastaveno, budou použity kryptogramy Recaptcha. To je speciální druh kryptogramů, který pomáhá při digitalizaci knih. Viz https://www.google.com/recaptcha/. Uživatel si může vybrat, že místo zadávání zobrazených písmen mu bude přehrána krátká zpráva obsahující čísla, která slouží jako kód. Pokud nejsou generovány žádné kryptogramy, server je pravděpodobně mimo službu.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE', 'Který typ kryptogramů použít?');
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE_DESC', 'Vyberte jeden z následujících typů: red (červený), white (bílý), blackglass (černé sklo). Tato volba funguje pouze s povoleným javascriptem.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB', 'Veřejný klíč pro kryptogramy Recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Zadejte veřejnou (public) část klíče pro komunikaci se serveren recaptcha.net. O vygenerování páru klíče (veřejný + soukromý klíč) můžete požádat na http://www.recaptcha.net/api/getkey');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Zadejte veřejnou (public) část klíče pro komunikaci se serveren recaptcha.net. O vygenerování páru klíče (veřejný + soukromý klíč) můžete požádat na https://www.google.com/recaptcha/admin');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV', 'Soukromý klíč recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Zadejte soukromou (private) část klíče pro komunikaci se serveren recaptcha.net. O vygenerování páru klíče (veřejný + soukromý klíč) můžete požádat na http://www.recaptcha.net/api/getkey');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Zadejte soukromou (private) část klíče pro komunikaci se serveren recaptcha.net. O vygenerování páru klíče (veřejný + soukromý klíč) můžete požádat na https://www.google.com/recaptcha/admin');
 
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL', 'Vynutit kryptogramy po uplynutí kolika dní?');
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL_DESC', 'Použití kryptogramů může být vynuceno v závislosti na stáří článků. Zadejte počet dní, po jejichž uplynutí od vydání článku je třeba zadat kryptogram. Hodnota 0 znamená, že kryptogramy budou použity vždy.');
@@ -42,5 +42,5 @@
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_CAPTCHAS', 'Nezadal(a) jsi správný řetězec podle antispamového obrázku. Podívej se na kryptogram prosím ještě jednou a zadej správné hodnoty.');
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_RECAPTCHA', 'Nezadali jste veřejný/soukromý klíč v nastavení kryptogramů recaptcha. Kryptogramy budou vypnuty. Pokud je chcete používat, zadejte prosím oba dva klíče v nastavení pluginu Recaptcha, nebo použijte obyčejné kryptogramy (plugin "antispamové metody").');
 
-@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Recaptcha je zvláštní druh <a href="http://en.wikipedia.com/wiki/Captcha">kryptogramu</a>. Uživatel musí rozpoznat dvě slova. První systémem výzva-odpověď (ochrana před spamem), a druhé, které pomáhá při digitalizaci knih. Navíc zrakově postižení lidé mohou použít audio-kryptogram. Pro více informací se podívejte na stránku <a href="http://www.recaptcha.net">www.recaptcha.net</a>.<br/>Pamatujte, že abyste mohli používat tento plugin, musíte se registrovat na zmíněné webové stránce.O klíč můžete požádat  <a href="http://www.recaptcha.net/api/getkey?app=serendipity&domain=');
+@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Recaptcha je zvláštní druh <a href="http://en.wikipedia.com/wiki/Captcha">kryptogramu</a>. Uživatel musí rozpoznat dvě slova. První systémem výzva-odpověď (ochrana před spamem), a druhé, které pomáhá při digitalizaci knih. Navíc zrakově postižení lidé mohou použít audio-kryptogram. Pro více informací se podívejte na stránku <a href="https://www.google.com/recaptcha/">https://www.google.com/recaptcha/</a>.<br/>Pamatujte, že abyste mohli používat tento plugin, musíte se registrovat na zmíněné webové stránce.O klíč můžete požádat <a href="https://www.google.com/recaptcha/admin');
 @define('PLUGIN_EVENT_RECAPTCHA_INFO2', '">tady</a>. <br/> Pamatujte také prosím, že tento plugin se bude při každém komentáři dotazovat serveru recaptcha, a může proto zpomalit načítání stránek. Pokud bude server recaptcha vypnutý, pak nebudou použity žádné kryptogramy.');

--- a/serendipity_event_recaptcha/UTF-8/lang_de.inc.php
+++ b/serendipity_event_recaptcha/UTF-8/lang_de.inc.php
@@ -14,16 +14,16 @@
 
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA', 'Recaptcha aktivieren');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Wenn diese Funktion aktiviert ist, wird ein Recaptcha generiert. Diese spezielle Art von Capchas helfen Bücher zu digitalisieren. Weitere Informationen finden Sie unter http://www.recaptcha.net. Statt der Eingabe der angezeigten Buchstaben, kann sich der Benutzer auch alternativ eine Nachricht anhören, und die gehörten Nummern eigeben. Wenn kein Captcha geniert wird, kann es sein das der Recapcha-Server nicht erreichbar ist.');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Wenn diese Funktion aktiviert ist, wird ein Recaptcha generiert. Diese spezielle Art von Capchas helfen Bücher zu digitalisieren. Weitere Informationen finden Sie unter https://www.google.com/recaptcha/. Statt der Eingabe der angezeigten Buchstaben, kann sich der Benutzer auch alternativ eine Nachricht anhören, und die gehörten Nummern eigeben. Wenn kein Captcha geniert wird, kann es sein das der Recapcha-Server nicht erreichbar ist.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE', 'Stil der Recapchas welcher genutzt wird');
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE_DESC', 'Rot, weiss oder schwarz-glasig. Dies funktioniert nur, wenn Javascirpt aktiviert ist.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB', 'Geben Sie den öffentlicher Schlüssel für Recaptcha ein');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Öffentliches Schlüsselpar für die Kommunikation mit dem recaptcha.net Server. Ein öffentliches/privates Schlüsselpaar kann unter http://www.recaptcha.net/api/getkey angefordert werden.');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Öffentliches Schlüsselpar für die Kommunikation mit dem recaptcha.net Server. Ein öffentliches/privates Schlüsselpaar kann unter https://www.google.com/recaptcha/admin angefordert werden.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV', 'Geben Sie den privaten Schlüssel für Recaptcha ein');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Privates Schlüsselpar für die Kommunikation mit derm recaptcha.net Server. Ein öffentliches/privates Schlüsselpaar kann unter http://www.recaptcha.net/api/getkey angefordert werden.');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Privates Schlüsselpar für die Kommunikation mit derm recaptcha.net Server. Ein öffentliches/privates Schlüsselpaar kann unter https://www.google.com/recaptcha/admin angefordert werden.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL', 'Anzahl Tage nach der die Eingabe von Recaptchas erzwungen wird');
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL_DESC', 'Recaptchas können abhängig vom Alter des Artikels erzwungen werden. Hier kann die Anzahl der Tage eingegeben werden, nach der die korrekte Eingabe eines Recaptchas notwendig wird. Ist dieser Wert 0, werden Recaptchas immer angezeigt.');
@@ -41,6 +41,6 @@
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_CAPTCHAS', 'Sie haben keine gültige Zeichenkette in die Spam-Schutz Box eingegeben. Bitten betrachten Sie das angezeigte Bild an und geben Sie die entsprechenden Werte ein.');
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_RECAPTCHA', 'Sie haben keinen öffentlichen/privaten Schlüssel in der Recapcha-Konfiguration eingegeben. Es werden keine  Recaptchas verwendet. Wenn Sie Recaptchas nutzen wollen, geben Sie bitte die entsprechenden Schlüssel im Konfigurations-Bereich des Recaptcha-Plugins ein oder verwenden Sie die herkömlichen Captchas.');
 
-@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Ein Recaptcha ist eine spezielle Art von  <a href="http://de.wikipedia.com/wiki/Captcha">Captcha</a>. Der Benutzer muss zwei Worte erkennen: Eines um Spam zu verhindern, dass andere um die Digitalisierung von Büchern zu unterstützen. Sehbehinderte Menschen können sich auch ein akustisches Recaptcha anhören. Weitere Informationen finden Sie unter <a href="http://www.recaptcha.net">www.recaptcha.net</a>.<br/>Bitte beachten Sie, wenn sie Recaptcha nutzen wollen, dass Sie sich bei der genannten Webseite registrieren müssen. Einen Schlüssel können Sie <a href="http://www.recaptcha.net/api/getkey?app=serendipity&domain=');
+@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Ein Recaptcha ist eine spezielle Art von  <a href="http://de.wikipedia.com/wiki/Captcha">Captcha</a>. Der Benutzer muss zwei Worte erkennen: Eines um Spam zu verhindern, dass andere um die Digitalisierung von Büchern zu unterstützen. Sehbehinderte Menschen können sich auch ein akustisches Recaptcha anhören. Weitere Informationen finden Sie unter <a href="https://www.google.com/recaptcha/">https://www.google.com/recaptcha/</a>.<br/>Bitte beachten Sie, wenn sie Recaptcha nutzen wollen, dass Sie sich bei der genannten Webseite registrieren müssen. Einen Schlüssel können Sie <a href="https://www.google.com/recaptcha/admin');
 @define('PLUGIN_EVENT_RECAPTCHA_INFO2', '">hier</a> anfordern. <br/> Bitte beachten Sie auch, dass dieses Plugin jedes mal Anfragen an den recaptcha.net Server sendet. Dies kann den Ladevorgang der Artikel verlangsamen. Wenn ein Timeout auftritt, wird kein Recaptcha angezeigt');
 

--- a/serendipity_event_recaptcha/lang_cs.inc.php
+++ b/serendipity_event_recaptcha/lang_cs.inc.php
@@ -15,16 +15,16 @@
 
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA', 'Použít kryptogramy Recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Pokud je nastaveno, budou použity kryptogramy Recaptcha. To je speciální druh kryptogramù, který pomáhá pøi digitalizaci knih. Viz http://www.recaptcha.net. Uživatel si mùže vybrat, že místo zadávání zobrazených písmen mu bude pøehrána krátká zpráva obsahující èísla, která slouží jako kód. Pokud nejsou generovány žádné kryptogramy, server je pravdìpodobnì mimo službu.');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Pokud je nastaveno, budou použity kryptogramy Recaptcha. To je speciální druh kryptogramù, který pomáhá pøi digitalizaci knih. Viz https://www.google.com/recaptcha/. Uživatel si mùže vybrat, že místo zadávání zobrazených písmen mu bude pøehrána krátká zpráva obsahující èísla, která slouží jako kód. Pokud nejsou generovány žádné kryptogramy, server je pravdìpodobnì mimo službu.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE', 'Který typ kryptogramù použít?');
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE_DESC', 'Vyberte jeden z následujících typù: red (èervený), white (bílý), blackglass (èerné sklo). Tato volba funguje pouze s povoleným javascriptem.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB', 'Veøejný klíè pro kryptogramy Recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Zadejte veøejnou (public) èást klíèe pro komunikaci se serveren recaptcha.net. O vygenerování páru klíèe (veøejný + soukromý klíè) mùžete požádat na http://www.recaptcha.net/api/getkey');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Zadejte veøejnou (public) èást klíèe pro komunikaci se serveren recaptcha.net. O vygenerování páru klíèe (veøejný + soukromý klíè) mùžete požádat na https://www.google.com/recaptcha/admin');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV', 'Soukromý klíè recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Zadejte soukromou (private) èást klíèe pro komunikaci se serveren recaptcha.net. O vygenerování páru klíèe (veøejný + soukromý klíè) mùžete požádat na http://www.recaptcha.net/api/getkey');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Zadejte soukromou (private) èást klíèe pro komunikaci se serveren recaptcha.net. O vygenerování páru klíèe (veøejný + soukromý klíè) mùžete požádat na https://www.google.com/recaptcha/admin');
 
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL', 'Vynutit kryptogramy po uplynutí kolika dní?');
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL_DESC', 'Použití kryptogramù mùže být vynuceno v závislosti na stáøí èlánkù. Zadejte poèet dní, po jejichž uplynutí od vydání èlánku je tøeba zadat kryptogram. Hodnota 0 znamená, že kryptogramy budou použity vždy.');
@@ -42,5 +42,5 @@
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_CAPTCHAS', 'Nezadal(a) jsi správný øetìzec podle antispamového obrázku. Podívej se na kryptogram prosím ještì jednou a zadej správné hodnoty.');
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_RECAPTCHA', 'Nezadali jste veøejný/soukromý klíè v nastavení kryptogramù recaptcha. Kryptogramy budou vypnuty. Pokud je chcete používat, zadejte prosím oba dva klíèe v nastavení pluginu Recaptcha, nebo použijte obyèejné kryptogramy (plugin "antispamové metody").');
 
-@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Recaptcha je zvláštní druh <a href="http://en.wikipedia.com/wiki/Captcha">kryptogramu</a>. Uživatel musí rozpoznat dvì slova. První systémem výzva-odpovìï (ochrana pøed spamem), a druhé, které pomáhá pøi digitalizaci knih. Navíc zrakovì postižení lidé mohou použít audio-kryptogram. Pro více informací se podívejte na stránku <a href="http://www.recaptcha.net">www.recaptcha.net</a>.<br/>Pamatujte, že abyste mohli používat tento plugin, musíte se registrovat na zmínìné webové stránce.O klíè mùžete požádat  <a href="http://www.recaptcha.net/api/getkey?app=serendipity&domain=');
+@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Recaptcha je zvláštní druh <a href="http://en.wikipedia.com/wiki/Captcha">kryptogramu</a>. Uživatel musí rozpoznat dvì slova. První systémem výzva-odpovìï (ochrana pøed spamem), a druhé, které pomáhá pøi digitalizaci knih. Navíc zrakovì postižení lidé mohou použít audio-kryptogram. Pro více informací se podívejte na stránku <a href="https://www.google.com/recaptcha/">https://www.google.com/recaptcha/</a>.<br/>Pamatujte, že abyste mohli používat tento plugin, musíte se registrovat na zmínìné webové stránce.O klíè mùžete požádat <a href="https://www.google.com/recaptcha/admin');
 @define('PLUGIN_EVENT_RECAPTCHA_INFO2', '">tady</a>. <br/> Pamatujte také prosím, že tento plugin se bude pøi každém komentáøi dotazovat serveru recaptcha, a mùže proto zpomalit naèítání stránek. Pokud bude server recaptcha vypnutý, pak nebudou použity žádné kryptogramy.');

--- a/serendipity_event_recaptcha/lang_cz.inc.php
+++ b/serendipity_event_recaptcha/lang_cz.inc.php
@@ -15,16 +15,16 @@
 
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA', 'Pou¾ít kryptogramy Recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Pokud je nastaveno, budou pou¾ity kryptogramy Recaptcha. To je speciální druh kryptogramù, který pomáhá pøi digitalizaci knih. Viz http://www.recaptcha.net. U¾ivatel si mù¾e vybrat, ¾e místo zadávání zobrazených písmen mu bude pøehrána krátká zpráva obsahující èísla, která slou¾í jako kód. Pokud nejsou generovány ¾ádné kryptogramy, server je pravdìpodobnì mimo slu¾bu.');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Pokud je nastaveno, budou pou¾ity kryptogramy Recaptcha. To je speciální druh kryptogramù, který pomáhá pøi digitalizaci knih. Viz https://www.google.com/recaptcha/. U¾ivatel si mù¾e vybrat, ¾e místo zadávání zobrazených písmen mu bude pøehrána krátká zpráva obsahující èísla, která slou¾í jako kód. Pokud nejsou generovány ¾ádné kryptogramy, server je pravdìpodobnì mimo slu¾bu.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE', 'Který typ kryptogramù pou¾ít?');
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE_DESC', 'Vyberte jeden z následujících typù: red (èervený), white (bílý), blackglass (èerné sklo). Tato volba funguje pouze s povoleným javascriptem.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB', 'Veøejný klíè pro kryptogramy Recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Zadejte veøejnou (public) èást klíèe pro komunikaci se serveren recaptcha.net. O vygenerování páru klíèe (veøejný + soukromý klíè) mù¾ete po¾ádat na http://www.recaptcha.net/api/getkey');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Zadejte veøejnou (public) èást klíèe pro komunikaci se serveren recaptcha.net. O vygenerování páru klíèe (veøejný + soukromý klíè) mù¾ete po¾ádat na https://www.google.com/recaptcha/admin');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV', 'Soukromý klíè recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Zadejte soukromou (private) èást klíèe pro komunikaci se serveren recaptcha.net. O vygenerování páru klíèe (veøejný + soukromý klíè) mù¾ete po¾ádat na http://www.recaptcha.net/api/getkey');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Zadejte soukromou (private) èást klíèe pro komunikaci se serveren recaptcha.net. O vygenerování páru klíèe (veøejný + soukromý klíè) mù¾ete po¾ádat na https://www.google.com/recaptcha/admin');
 
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL', 'Vynutit kryptogramy po uplynutí kolika dní?');
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL_DESC', 'Pou¾ití kryptogramù mù¾e být vynuceno v závislosti na stáøí èlánkù. Zadejte poèet dní, po jejich¾ uplynutí od vydání èlánku je tøeba zadat kryptogram. Hodnota 0 znamená, ¾e kryptogramy budou pou¾ity v¾dy.');
@@ -42,5 +42,5 @@
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_CAPTCHAS', 'Nezadal(a) jsi správný øetìzec podle antispamového obrázku. Podívej se na kryptogram prosím je¹tì jednou a zadej správné hodnoty.');
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_RECAPTCHA', 'Nezadali jste veøejný/soukromý klíè v nastavení kryptogramù recaptcha. Kryptogramy budou vypnuty. Pokud je chcete pou¾ívat, zadejte prosím oba dva klíèe v nastavení pluginu Recaptcha, nebo pou¾ijte obyèejné kryptogramy (plugin "antispamové metody").');
 
-@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Recaptcha je zvlá¹tní druh <a href="http://en.wikipedia.com/wiki/Captcha">kryptogramu</a>. U¾ivatel musí rozpoznat dvì slova. První systémem výzva-odpovìï (ochrana pøed spamem), a druhé, které pomáhá pøi digitalizaci knih. Navíc zrakovì posti¾ení lidé mohou pou¾ít audio-kryptogram. Pro více informací se podívejte na stránku <a href="http://www.recaptcha.net">www.recaptcha.net</a>.<br/>Pamatujte, ¾e abyste mohli pou¾ívat tento plugin, musíte se registrovat na zmínìné webové stránce.O klíè mù¾ete po¾ádat  <a href="http://www.recaptcha.net/api/getkey?app=serendipity&domain=');
+@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Recaptcha je zvlá¹tní druh <a href="http://en.wikipedia.com/wiki/Captcha">kryptogramu</a>. U¾ivatel musí rozpoznat dvì slova. První systémem výzva-odpovìï (ochrana pøed spamem), a druhé, které pomáhá pøi digitalizaci knih. Navíc zrakovì posti¾ení lidé mohou pou¾ít audio-kryptogram. Pro více informací se podívejte na stránku <a href="https://www.google.com/recaptcha/">https://www.google.com/recaptcha/</a>.<br/>Pamatujte, ¾e abyste mohli pou¾ívat tento plugin, musíte se registrovat na zmínìné webové stránce.O klíè mù¾ete po¾ádat  <a href="https://www.google.com/recaptcha/admin');
 @define('PLUGIN_EVENT_RECAPTCHA_INFO2', '">tady</a>. <br/> Pamatujte také prosím, ¾e tento plugin se bude pøi ka¾dém komentáøi dotazovat serveru recaptcha, a mù¾e proto zpomalit naèítání stránek. Pokud bude server recaptcha vypnutý, pak nebudou pou¾ity ¾ádné kryptogramy.');

--- a/serendipity_event_recaptcha/lang_de.inc.php
+++ b/serendipity_event_recaptcha/lang_de.inc.php
@@ -14,16 +14,16 @@
 
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA', 'Recaptcha aktivieren');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Wenn diese Funktion aktiviert ist, wird ein Recaptcha generiert. Diese spezielle Art von Capchas helfen Bücher zu digitalisieren. Weitere Informationen finden Sie unter http://www.recaptcha.net. Statt der Eingabe der angezeigten Buchstaben, kann sich der Benutzer auch alternativ eine Nachricht anhören, und die gehörten Nummern eigeben. Wenn kein Captcha geniert wird, kann es sein das der Recapcha-Server nicht erreichbar ist.');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'Wenn diese Funktion aktiviert ist, wird ein Recaptcha generiert. Diese spezielle Art von Capchas helfen Bücher zu digitalisieren. Weitere Informationen finden Sie unter https://www.google.com/recaptcha/. Statt der Eingabe der angezeigten Buchstaben, kann sich der Benutzer auch alternativ eine Nachricht anhören, und die gehörten Nummern eigeben. Wenn kein Captcha geniert wird, kann es sein das der Recapcha-Server nicht erreichbar ist.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE', 'Stil der Recapchas welcher genutzt wird');
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE_DESC', 'Rot, weiss oder schwarz-glasig. Dies funktioniert nur, wenn Javascirpt aktiviert ist.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB', 'Geben Sie den öffentlicher Schlüssel für Recaptcha ein');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Öffentliches Schlüsselpar für die Kommunikation mit dem recaptcha.net Server. Ein öffentliches/privates Schlüsselpaar kann unter http://www.recaptcha.net/api/getkey angefordert werden.');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Öffentliches Schlüsselpar für die Kommunikation mit dem recaptcha.net Server. Ein öffentliches/privates Schlüsselpaar kann unter https://www.google.com/recaptcha/admin angefordert werden.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV', 'Geben Sie den privaten Schlüssel für Recaptcha ein');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Privates Schlüsselpar für die Kommunikation mit derm recaptcha.net Server. Ein öffentliches/privates Schlüsselpaar kann unter http://www.recaptcha.net/api/getkey angefordert werden.');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Privates Schlüsselpar für die Kommunikation mit derm recaptcha.net Server. Ein öffentliches/privates Schlüsselpaar kann unter https://www.google.com/recaptcha/admin angefordert werden.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL', 'Anzahl Tage nach der die Eingabe von Recaptchas erzwungen wird');
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL_DESC', 'Recaptchas können abhängig vom Alter des Artikels erzwungen werden. Hier kann die Anzahl der Tage eingegeben werden, nach der die korrekte Eingabe eines Recaptchas notwendig wird. Ist dieser Wert 0, werden Recaptchas immer angezeigt.');
@@ -41,6 +41,6 @@
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_CAPTCHAS', 'Sie haben keine gültige Zeichenkette in die Spam-Schutz Box eingegeben. Bitten betrachten Sie das angezeigte Bild an und geben Sie die entsprechenden Werte ein.');
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_RECAPTCHA', 'Sie haben keinen öffentlichen/privaten Schlüssel in der Recapcha-Konfiguration eingegeben. Es werden keine  Recaptchas verwendet. Wenn Sie Recaptchas nutzen wollen, geben Sie bitte die entsprechenden Schlüssel im Konfigurations-Bereich des Recaptcha-Plugins ein oder verwenden Sie die herkömlichen Captchas.');
 
-@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Ein Recaptcha ist eine spezielle Art von  <a href="http://de.wikipedia.com/wiki/Captcha">Captcha</a>. Der Benutzer muss zwei Worte erkennen: Eines um Spam zu verhindern, dass andere um die Digitalisierung von Büchern zu unterstützen. Sehbehinderte Menschen können sich auch ein akustisches Recaptcha anhören. Weitere Informationen finden Sie unter <a href="http://www.recaptcha.net">www.recaptcha.net</a>.<br/>Bitte beachten Sie, wenn sie Recaptcha nutzen wollen, dass Sie sich bei der genannten Webseite registrieren müssen. Einen Schlüssel können Sie <a href="http://www.recaptcha.net/api/getkey?app=serendipity&domain=');
-@define('PLUGIN_EVENT_RECAPTCHA_INFO2', '">hier</a> anfordern. <br/> Bitte beachten Sie auch, dass dieses Plugin jedes mal Anfragen an den recaptcha.net Server sendet. Dies kann den Ladevorgang der Artikel verlangsamen. Wenn ein Timeout auftritt, wird kein Recaptcha angezeigt');
+@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'Ein Recaptcha ist eine spezielle Art von  <a href="http://de.wikipedia.com/wiki/Captcha">Captcha</a>. Der Benutzer muss zwei Worte erkennen: Eines um Spam zu verhindern, dass andere um die Digitalisierung von Büchern zu unterstützen. Sehbehinderte Menschen können sich auch ein akustisches Recaptcha anhören. Weitere Informationen finden Sie unter <a href="https://www.google.com/recaptcha/">https://www.google.com/recaptcha/</a>.<br/>Bitte beachten Sie, wenn sie Recaptcha nutzen wollen, dass Sie sich bei der genannten Webseite registrieren müssen. Einen Schlüssel können Sie <a href="https://www.google.com/recaptcha/admin');
+@define('PLUGIN_EVENT_RECAPTCHA_INFO2', '">hier</a> anfordern. <br/> Bitte beachten Sie auch, dass dieses Plugin jedes mal Anfragen an den reCAPTCHA Server sendet. Dies kann den Ladevorgang der Artikel verlangsamen. Wenn ein Timeout auftritt, wird kein Recaptcha angezeigt');
 

--- a/serendipity_event_recaptcha/lang_en.inc.php
+++ b/serendipity_event_recaptcha/lang_en.inc.php
@@ -14,16 +14,16 @@
 
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA', 'Use Recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'If set, a recaptcha will be generated. This is a special kind of captcha, that will help digitize books. See http://www.recaptcha.net for more details. Instead of entering the displayed letters, the user can alternatively listen to a message and type the numbers that were played. If no captcha is generated, the recaptcha server might be down.');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_DESC', 'If set, a recaptcha will be generated. This is a special kind of captcha, that will help digitize books. See https://www.google.com/recaptcha/ for more details. Instead of entering the displayed letters, the user can alternatively listen to a message and type the numbers that were played. If no captcha is generated, the recaptcha server might be down.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE', 'Which style to use for recaptcha.');
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_STYLE_DESC', 'Chose one of the available styles: red, white, blackglass. This only works with javascript enabled.');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB', 'Public key for recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Provide a public key pair for communicating with the recaptcha.net site. You can request a public/private key pair at http://www.recaptcha.net/api/getkey');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PUB_DESC', 'Provide a public key pair for communicating with the recaptcha.net site. You can request a public/private key pair at https://www.google.com/recaptcha/admin');
 
 @define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV', 'Private key for recaptcha');
-@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Provide a private key pair for communicating with the recaptcha.net site. You can request a public/private key pair at http://www.recaptcha.net/api/getkey');
+@define('PLUGIN_EVENT_RECAPTCHA_RECAPTCHA_PRIV_DESC', 'Provide a private key pair for communicating with the recaptcha.net site. You can request a public/private key pair at https://www.google.com/recaptcha/admin');
 
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL', 'Force captchas after how many days');
 @define('PLUGIN_EVENT_RECAPTCHA_CAPTCHAS_TTL_DESC', 'Captchas can be enforced depending on the age of your articles. Enter the amount of days after which entering a correct captcha is necessary. If set to 0, captchas will always be used.');
@@ -41,5 +41,5 @@
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_CAPTCHAS', 'You did not enter the correct string displayed in the spam-prevention image box. Please look at the image and enter the values displayed there.');
 @define('PLUGIN_EVENT_RECAPTCHA_ERROR_RECAPTCHA', 'You did not enter a public/private key for the recaptcha setup. No Captchas will be used. If you want to use Recaptchas, please enter the keys in the configuration section of the captcha plugin or switch to traditional Captchas.');
 
-@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'A Recaptcha is a special <a href="http://en.wikipedia.com/wiki/Captcha">captcha</a>. The user will have to recognize 2 words, one as a challenge-response to prevent spam, and a second one to help digitizing books. Additionally visually impaired people may switch to an acoustic captcha. For more info, you might want to look at the website <a href="http://www.recaptcha.net">www.recaptcha.net</a>.<br/>Please note, that in order to use this plugin you\'ll have to register at this website. You can apply for a key <a href="http://www.recaptcha.net/api/getkey?app=serendipity&domain=');
-@define('PLUGIN_EVENT_RECAPTCHA_INFO2', '">here</a>. <br/> Please also note, that this plugin in will query the recaptcha.net server every time and might therefore slow down the loading of the articles and in case of a timeout, no captcha will be displayed.');
+@define('PLUGIN_EVENT_RECAPTCHA_INFO1', 'A Recaptcha is a special <a href="http://en.wikipedia.com/wiki/Captcha">captcha</a>. The user will have to recognize 2 words, one as a challenge-response to prevent spam, and a second one to help digitizing books. Additionally visually impaired people may switch to an acoustic captcha. For more info, you might want to look at the website <a href="https://www.google.com/recaptcha/">https://ww.google.com/recaptcha/</a>.<br/>Please note, that in order to use this plugin you\'ll have to register at this website. You can apply for a key <a href="https://www.google.com/recaptcha/admin');
+@define('PLUGIN_EVENT_RECAPTCHA_INFO2', '">here</a>. <br/> Please also note, that this plugin in will query the reCAPTCHA server every time and might therefore slow down the loading of the articles and in case of a timeout, no captcha will be displayed.');

--- a/serendipity_event_recaptcha/serendipity_event_recaptcha.php
+++ b/serendipity_event_recaptcha/serendipity_event_recaptcha.php
@@ -15,10 +15,6 @@ include dirname(__FILE__) . '/lang_en.inc.php';
 
 require_once dirname(__FILE__) . '/recaptcha/recaptchalib.php';
 
-$GLOBALS['recaptcha_api_server'] = 'http://api.recaptcha.net';
-$GLOBALS['recaptcha_api_secure_server'] = 'https://api-secure.recaptcha.net';
-$GLOBALS['recaptcha_verify_server'] = 'api-verify.recaptcha.net';
-
 class serendipity_event_recaptcha extends serendipity_event
 {
 var $error=null;


### PR DESCRIPTION
The in-plugin documentation (descriptions) show old URLs from recaptcha.net instead of the current ones from Google.

Those old URLs are defined in the plugin code, too, but never used.

Thanks to Imajica for the heads-up in https://board.s9y.org/viewtopic.php?f=2&t=21037