### PR TITLE
HTTP500 - prevents crash when response is an array

### DIFF
--- a/alpha/serendipity_event_challengeresponse.php
+++ b/alpha/serendipity_event_challengeresponse.php
@@ -73,7 +73,9 @@ class serendipity_event_challengeresponse extends serendipity_event {
             switch($event) {
                 case 'frontend_saveComment':
                     if (!is_array($eventData) || serendipity_db_bool($eventData['allow_comments'])) {
-                        if (strtolower($_POST['response']) != strtolower($this->get_config('response'))) {
+                        if (is_string($_POST['response']) && strtolower($_POST['response']) === strtolower($this->get_config('response'))) {
+                            return true;
+                        }else{
                             $eventData = array('allow_comments' => false);
                             $serendipity['messagestack']['comments'][] = $this->get_config('error');
                             return false;


### PR DESCRIPTION
The comment submit will crash when the POST request is supplied with a form field _response_ as as array.

s9y-Version: 2.1-rc1

Reproduction: Modify the form field to _response[]_

Error:
`PHP Fatal error:  Uncaught ErrorException: Warning: strtolower() expects parameter 1 to be string, array given in plugins/alpha/serendipity_event_challengeresponse.php:76`