### PR TITLE
Get rid of $GLOBALS['entry'].

### DIFF
--- a/serendipity_event_social/ChangeLog
+++ b/serendipity_event_social/ChangeLog
@@ -1,3 +1,6 @@
+0.12.1:
+    * Fix use of description from the metadesc-plugin
+
 0.12:
     * Ignore smileys graphics for og:image
     * Use entry picture from the timeline theme if set

--- a/serendipity_event_social/serendipity_event_social.php
+++ b/serendipity_event_social/serendipity_event_social.php
@@ -16,7 +16,7 @@ class serendipity_event_social extends serendipity_event {
         $propbag->add('description',   PLUGIN_EVENT_SOCIAL_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'onli, Matthias Mees, Thomas Hochstein');
-        $propbag->add('version',       '0.12');
+        $propbag->add('version',       '0.12.1');
         $propbag->add('requirements',  array(
             'serendipity' => '2.0'
         ));
@@ -149,7 +149,7 @@ class serendipity_event_social extends serendipity_event {
                         echo '<meta name="twitter:card" content="summary" />' . "\n";
                         echo '<meta property="og:title" content="' . serendipity_specialchars($entry['title']) . '" />' . "\n";
                         # get desciption from serendipity_event_metadesc, if set; take first 200 chars from body otherwise
-                        $meta_description = strip_tags($GLOBALS['entry'][0]['properties']['meta_description']);
+                        $meta_description = strip_tags($entry['properties']['meta_description']);
                         if (empty($meta_description)) {
                                                                  # /\s+/: multiple newline and whitespaces
                             $meta_description = trim(preg_replace('/\s+/', ' ', substr(strip_tags($entry['body']), 0, 200))) . '...';


### PR DESCRIPTION
See <https://board.s9y.org/viewtopic.php?f=4&t=21256&p=10447310#p10447310>.

`$GLOBALS['entry']` doesn't contain any data any longer in 2.1, AFAICS.

Signed-off-by: Thomas Hochstein <thh@inter.net>