### PR TITLE
Add local documentation to dejure.org plugin.

### DIFF
--- a/serendipity_event_dejure/ChangeLog
+++ b/serendipity_event_dejure/ChangeLog
@@ -1,3 +1,6 @@
+1.8:
+    * Add local documentation (German language only).
+
 1.7:
     * Add option for linking to buzer.de
     * Add option to exclude headings from linking.

--- a/serendipity_event_dejure/documentation_de.html
+++ b/serendipity_event_dejure/documentation_de.html
@@ -1,0 +1,168 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>Hilfedatei: dejure.org-Rechtsvernetzung</title>
+<style type="text/css">
+body {
+  font-family: Arial, sans-serif!important;
+  margin: 20px;
+}
+ol li {
+  margin-bottom: 0.5em;
+}
+h2 {
+  background: #efefef;	
+  padding: 0.5em;
+}
+p {
+  max-width: 60em;
+}
+.titel {
+  background: #cfcfcf;    
+  margin: 0;
+  padding: 0.5em;
+}
+#inhalt {
+  background: #efefef;	
+  margin: 0;
+  padding: 0.5em;
+}
+#inhalt h2 {
+  padding: 0;
+}
+</style>
+</head>
+<body>
+<h1 class="titel"><i>dejure.org</i>-Vernetzungsfunktion</h1>
+</div>
+<div id="inhalt">
+<h2>Inhalt</h2>
+<ol>
+    <li><a href="#description">Beschreibung</a></li>
+    <li><a href="#config">Konfiguration</a></li>
+    <li><a href="#faq">Fragen und Antworten</a></li>
+</ol>
+</div>
+
+
+<p>Diese Erweiterung verlinkt automatisch zitierte Gesetze und
+Rechtsprechung (Aktenzeichen und Fundstellen) mit den Inhalten von <a
+href="https://dejure.org/"><i>dejure.org</i></a>.</p>
+
+<h2 id="description">Beschreibung</h2>
+
+<p>Als Anbieter von juristischen Inhalten im Internet können Sie mit
+dieser kostenlos von <i>dejure.org</i> bereitgestellten Funktion ohne
+eigenen redaktionellen Aufwand Ihre Texte mit Gesetzen und
+Rechtsprechung selbständig verlinken lassen. Urteile,
+Pressemitteilungen, oder sonstige juristische Beiträge - darin
+vorkommende Zitate von Gesetzesnormen oder Gerichtsentscheidungen
+werden automatisch mit den entsprechenden Rechtsquellen auf
+<i>dejure.org</i> verlinkt. Es werden Blogbeiträge wie auch Kommentare
+vernetzt.</p>
+
+<h2 id="config">Konfiguration</h2>
+
+<h3>E-Mail-Adresse des Blogbetreibers</h3>
+
+<p>Die dort angegebene E-Mail-Adresse wird an <i>dejure.org</i>
+übertragen, um bei technischen Problemen eine Kontaktaufnahme zu
+ermöglichen.</p>
+
+<p>Überdies wird der <strong>Hostname</strong> ihres Servers übertragen.</p>
+
+<h3>Newsletter</h3>
+
+<p>Hier können Sie den <i>dejure.org</i>-Newsletter abonnieren.</p>
+
+<h3>Links öffnen...</h3>
+
+<p>Das <code>target</code>-Attribut (Linkziel) der erzeugten Links.
+Geben Sie hier <code>_blank</code> ein, werden Links in einem neuen
+Fenster geöffnet.</p>
+
+<h3>CSS-Klasse für dejure.org-Links</h3>
+
+<p>Das <code>class</code>-Attribut der erzeugten Links.</p>
+
+<h3>Stil der dejure.org-Links</h3>
+
+<p>Die Links können so erzeugt werden, dass nur die Paragraphen-Nummer
+verlinkt wird (<b>§ 278</b> Abs. 1 BGB) oder dass der Link nach
+Möglichkeit auch Absätze und Gesetzesbezeichnung mit umfasst (<b>§ 278
+Abs. 1 BGB</b>).</p>
+
+<h3>Überschriften von Verlinkung ausnehmen</h3>
+
+<p>Sie können die Verlinkung von Paragraphen oder Urteile in
+Überschriften unterbinden.</p>
+
+<h3>Gesetze bei buzer.de verlinken</h3>
+
+<p><i>buzer.de</i> ist ein weiterer juristischer Informationsdienst,
+der zwar keine Urteile, aber dafür das gesamte deutsche Bundesrecht
+sammelt. Sollte eine Vorschrift bei <i>dejure.org</i> nicht zur
+Verfügung stehen, können Sie stattdessen auf die Vorschrift bei
+<i>buzer.de</i> verlinken.</p>
+
+<h3>Cache leeren</h3>
+
+<p>Wenn Sie eine der vorstehenden Einstellungen für die Erzeugung von
+Links (Linkziel, CSS-Klasse, Stil, Ausnehmen von Überschriften oder
+Verlinkung zu <i>buzer.de</i>) geändert haben, sollten Sie den Cache
+leeren, sonst sehen Ihre Besucher ggf. noch mehrere Tage die letzte
+gecachte Version mit den vorherigen Einstellungen.</p>
+
+<h2 id="faq">Fragen und Antworten</h2>
+
+<h3>Gehe ich irgendwelche Verpflichtungen oder Bindungen ein?</h3>
+
+<p>Nein. <i>dejure.org</i> stellt die Funktion kostenlos zur Verfügung
+und es steht Ihnen jederzeit frei, zu entscheiden, ob und in welchem
+Umfang Sie die Funktion nutzen.</p>
+
+<h3>Welche Gesetze werden verlinkt?</h3>
+
+<p>Der Gesetzesbestand von <i>dejure.org</i> umfaßt z.Zt. rund 270
+Gesetze aus fast allen Rechtsgebieten. Ergänzend können Sie auf das
+komplette Bundesrecht (über <i>buzer.de</i>) zugreifen.</p>
+
+<h3>Welche Urteile werden verlinkt?</h3>
+
+<p>Urteile, die in Ihren Texten mit einem Aktenzeichen oder einer
+Fundstelle zitiert werden, werden automatisch verlinkt, falls die
+entsprechende Entscheidung in der Datenbank von <i>dejure.org</i>
+enthalten ist.</p>
+
+<p>In der Rechtsprechungsdatenbank werden über eine Million
+Entscheidungen nachgewiesen, überwiegend mit frei verfügbarem
+Volltext. Die Datenbank wird fortlaufend aktualisiert. Zu den
+einzelnen Entscheidungen werden neben allgemeinen Informationen einen
+Link zu einer oder mehreren - in der Regel frei zugänglichen -
+Volltextveröffentlichungen im Internet angeboten. Darüber hinaus sind
+auch weitere Informationen wie Urteilsbesprechungen nachgewiesen.</p>
+
+<h3>Was passiert, wenn im Text bereits Links gesetzt sind?</h3>
+
+<p>Die Vernetzungsfunktion respektiert alle Links, die bereits im Text
+enthalten sind, auch solche zu anderen Gesetzesseiten. Das bedeutet,
+daß nur solche Gesetzes- und Rechtsprechungszitate, die noch nicht
+verlinkt sind, von der Funktion verarbeitet werden. Die
+Vernetzungsfunktion greift rein unterstützend ein und nimmt niemals
+die Freiheit der Verlinkung.</p>
+
+<h3>Wie zuverlässig ist die Funktion?</h3>
+
+<p>Die Funktion ist so konzipiert, daß möglichst viele Schreibweisen
+der Gesetzes- und Rechtsprechungszitate automatisch erkannt werden.
+Ein Scheitern der Erkennung ist sehr selten.</p>
+
+<h3>Kann ich auch einzelne Beiträge von der Vernetzung
+ausschließen?</h3>
+
+<p>Dafür müssen Sie lediglich <code><!-- ohnedjo --></code> am Anfang
+oder Ende des Beitrags einfügen. Dann wird der gesamte Beitrag von der
+Vernetzung ignoriert.
+
+</body>
+</html>

--- a/serendipity_event_dejure/serendipity_event_dejure.php
+++ b/serendipity_event_dejure/serendipity_event_dejure.php
@@ -12,7 +12,7 @@ if (file_exists($probelang)) {
 
 include dirname(__FILE__) . '/lang_en.inc.php';
 
-define('DJO_VERSION', '1.7');
+define('DJO_VERSION', '1.8');
 define('CACHE_VORHALT', 4); # (Tage) Wann ein vernetzter Text aus dem Cache entfernt und neu vernetzt werden soll
 
 class serendipity_event_dejure extends serendipity_event


### PR DESCRIPTION
German language only, as there will be very little need to link to German law and decisions in a foreign language blog.

Signed-off-by: Thomas Hochstein <thh@inter.net>