### PR TITLE
Remove dead or useless links to external plugin documentation.

### DIFF
--- a/serendipity_event_mobile_output/serendipity_event_mobile_output.php
+++ b/serendipity_event_mobile_output/serendipity_event_mobile_output.php
@@ -107,7 +107,6 @@ class serendipity_event_mobile_output extends serendipity_event
         $propbag->add('description',   PLUGIN_EVENT_MOBILE_OUTPUT_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        PLUGIN_EVENT_MOBILE_AUTHORS);
-        $propbag->add('website',       'http://c.mobile-seo.de/');
         $propbag->add('version',       PLUGIN_EVENT_MOBILE_VERSION);
         $propbag->add('requirements',  array(
             'serendipity' => '1.0',

--- a/serendipity_event_staticpage/serendipity_event_staticpage.php
+++ b/serendipity_event_staticpage/serendipity_event_staticpage.php
@@ -67,7 +67,6 @@ class serendipity_event_staticpage extends serendipity_event
 
         $propbag->add('name', STATICPAGE_TITLE);
         $propbag->add('description', STATICPAGE_TITLE_BLAHBLAH);
-        $propbag->add('website', 'http://board.s9y.org');
 
         $propbag->add('event_hooks', array(
             'backend_category_addNew'                           => true,

--- a/serendipity_plugin_twitter/serendipity_event_twitter.php
+++ b/serendipity_plugin_twitter/serendipity_event_twitter.php
@@ -55,7 +55,6 @@ class serendipity_event_twitter extends serendipity_plugin {
         $propbag->add('description',   PLUGIN_EVENT_TWITTER_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Grischa Brockhaus, Peter Heimann');
-        //$propbag->add('website',       'http://board.s9y.org');
         $propbag->add('requirements',  array(
             'serendipity' => '0.7',
             'smarty'      => '2.6.7',

--- a/serendipity_plugin_twitter/serendipity_plugin_twitter.php
+++ b/serendipity_plugin_twitter/serendipity_plugin_twitter.php
@@ -26,7 +26,6 @@ class serendipity_plugin_twitter extends serendipity_plugin {
         $propbag->add('description',   PLUGIN_TWITTER_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Grischa Brockhaus, Damian Luszczymak, Garvin Hicking');
-        //$propbag->add('website',       'http://board.s9y.org');
         $propbag->add('version',       PLUGIN_TWITTER_VERSION);
         $propbag->add('requirements',  array(
             'serendipity' => '0.8',


### PR DESCRIPTION
The 'website' property of plugins is used to link to external documentation. board.s9y.org does not contain such documentation; c.seo-mobile.de does no longer exist.