### PR TITLE
Fix function definition.

### DIFF
--- a/serendipity_event_dejure/serendipity_event_dejure.php
+++ b/serendipity_event_dejure/serendipity_event_dejure.php
@@ -157,7 +157,7 @@ class serendipity_event_dejure extends serendipity_event
         $this->setupDB();
     }
 
-    function uninstall() {
+    function uninstall(&$bag) {
         $this->dropDB();
     }
 


### PR DESCRIPTION
The declaration of uninstall() didn't match serendipity_plugin::uninstall, making PHP spew warnings to the log.

Signed-off-by: Thomas Hochstein <thh@inter.net>