### PR TITLE
Add ids as link targets to spartacus web pages.

### DIFF
--- a/emerge_spartacus.php
+++ b/emerge_spartacus.php
@@ -326,7 +326,7 @@ class emerge_spartacus {
             $author     = isset($plugin_data['properties']['author'])     ? $plugin_data['properties']['author']     : 'Serendipity Team';
 
             $x = '';
-            $x .= '<div class="plugin">';
+            $x .= '<div class="plugin" id="' . $this->encode($plugin_name) . '">';
             $x .= '<h4 class="plugin_summary">' . $this->encode($plugin_data['properties']['name']) . '</h4>';
             $x .= '<dl class="plugin_meta">';
             $x .= '<dt class="plugin_name">' . $this->encode($plugin_name) . '</dt>';


### PR DESCRIPTION
It would be nice to be able to link directly to a certain plugin, so add ids to the generated HTML.

Using the plugin name should make for unique ids without illegal characters.

As I'm not really familiar with this code and have no test installation, I'd like a review before merging, please. :-)

Signed-off-by: Thomas Hochstein <thh@inter.net>