### PR TITLE
change google.com and sitemap.org URLs to https

### DIFF
--- a/serendipity_event_google_sitemap/serendipity_event_google_sitemap.php
+++ b/serendipity_event_google_sitemap/serendipity_event_google_sitemap.php
@@ -7,7 +7,7 @@ if (IN_serendipity !== true) {
 
 /** This plugin builds a sitemap.xml according to sitemap.org's defintion of the
   * "Sitemap XML format" Version 0.9 after every save and publish.
-  * See http://www.sitemaps.org/protocol.html for details
+  * See https://www.sitemaps.org/protocol.html for details
   * 
   */
 
@@ -56,7 +56,7 @@ class serendipity_event_google_sitemap extends serendipity_event {
                 $propbag->add('type', 'string');
                 $propbag->add('name', PLUGIN_EVENT_SITEMAP_URL);
                 $propbag->add('description', PLUGIN_EVENT_SITEMAP_URL_DESC);
-                $propbag->add('default', 'http://www.google.com/webmasters/tools/ping?sitemap=%s;http://submissions.ask.com/ping?sitemap=%s');
+                $propbag->add('default', 'https://www.google.com/webmasters/tools/ping?sitemap=%s;http://submissions.ask.com/ping?sitemap=%s');
             break;
             case 'gzip_sitemap':
                 $propbag->add('type', 'boolean');


### PR DESCRIPTION
With google going https by default it makes sense to use the HTTPS url for sitemap submissions. Also the sitemap.org protocol spec redirects all requests to HTTPS, so change that url as well.