### PR TITLE
remove submissions.ask.com, no longer exists

### DIFF
--- a/serendipity_event_google_sitemap/serendipity_event_google_sitemap.php
+++ b/serendipity_event_google_sitemap/serendipity_event_google_sitemap.php
@@ -56,7 +56,7 @@ class serendipity_event_google_sitemap extends serendipity_event {
                 $propbag->add('type', 'string');
                 $propbag->add('name', PLUGIN_EVENT_SITEMAP_URL);
                 $propbag->add('description', PLUGIN_EVENT_SITEMAP_URL_DESC);
-                $propbag->add('default', 'https://www.google.com/webmasters/tools/ping?sitemap=%s;http://submissions.ask.com/ping?sitemap=%s');
+                $propbag->add('default', 'https://www.google.com/webmasters/tools/ping?sitemap=%s');
             break;
             case 'gzip_sitemap':
                 $propbag->add('type', 'boolean');


### PR DESCRIPTION
Remove obsolete ask.com submission URL, see:
https://board.s9y.org/viewtopic.php?f=3&t=17239