### PR TITLE
dsgvo: set default of commentform checkbox to false

### DIFF
--- a/serendipity_event_dsgvo_gdpr/ChangeLog
+++ b/serendipity_event_dsgvo_gdpr/ChangeLog
@@ -1,3 +1,4 @@
+1.1.0: Set default value of commentform checkbox to false
 1.0.6: Typos, German translation, frontend markup fix
 1.0.5: Added ability to export and/or remove comments made by users to comply with the Auskunftsgesuch
 1.0.3: Added ability to make themes provide a "legal.txt" with information, and a hard-coded internal array that yields information

--- a/serendipity_event_dsgvo_gdpr/serendipity_event_dsgvo_gdpr.php
+++ b/serendipity_event_dsgvo_gdpr/serendipity_event_dsgvo_gdpr.php
@@ -23,7 +23,7 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
         $propbag->add('description',   PLUGIN_EVENT_DSGVO_GDPR_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Serendipity Team');
-        $propbag->add('version', '1.0.6');
+        $propbag->add('version', '1.1.0');
         $propbag->add('requirements',  array(
             'serendipity' => '2.0',
             'smarty'      => '2.6.7',
@@ -88,7 +88,7 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
                 $propbag->add('type','boolean');
                 $propbag->add('name', PLUGIN_EVENT_DSGVO_GDPR_COMMENTFORM_CHECKBOX);
                 $propbag->add('description', PLUGIN_EVENT_DSGVO_GDPR_COMMENTFORM_CHECKBOX_DESC);
-                $propbag->add('default', 'true');
+                $propbag->add('default', 'false');
                 break;
 
             case 'anonymizeIp':


### PR DESCRIPTION
I think https://www.datenschutz-guru.de/braucht-mein-kontaktformular-jetzt-eine-checkbox/ is convincing and I remember we saw it like that as well. The checkbox should not be on by default then - this PR does that.