### PR TITLE
Add a button to the privacy draft to copy the pure html

### DIFF
--- a/serendipity_event_dsgvo_gdpr/ChangeLog
+++ b/serendipity_event_dsgvo_gdpr/ChangeLog
@@ -1,3 +1,6 @@
+1.2.0: Add button to copy pricvacy draft in html
+1.1.0: Set default value of commentform checkbox to false
+1.0.7: Properly quit once the CSV dump is sent, and not embed this in HTML 
 1.0.6: Typos, German translation, frontend markup fix
 1.0.5: Added ability to export and/or remove comments made by users to comply with the Auskunftsgesuch
 1.0.3: Added ability to make themes provide a "legal.txt" with information, and a hard-coded internal array that yields information

--- a/serendipity_event_dsgvo_gdpr/UTF-8/lang_de.inc.php
+++ b/serendipity_event_dsgvo_gdpr/UTF-8/lang_de.inc.php
@@ -124,3 +124,4 @@ Bestimmte Plugins können das Session-Cookie verwenden, um zusätzlich temporär
 @define('PLUGIN_EVENT_DSGVO_GDPR_BACKEND', 'Benutzerdaten verwalten');
 @define('PLUGIN_EVENT_DSGVO_GDPR_BACKEND_INFO', 'Hier können Sie einen exakt übereinstimmenden Benutzernamen oder eine E-Mail-Adresse eingeben, um diesen Benutzer zu entfernen oder seine Daten zu exportieren. Sie können mehrere Namen auf jeweils einer neuen Zeile eingeben.');
 @define('PLUGIN_EVENT_DSGVO_GDPR_BACKEND_DELFAIL', 'Um exportieren oder löschen zu können muss mindestens ein Benutzername oder eine E-Mail-Adresse eingegeben werden.');
+@define('PLUGIN_EVENT_DSGVO_GDPR_COPY_CLIPBOARD', 'In Zwischenablage kopieren');

--- a/serendipity_event_dsgvo_gdpr/lang_de.inc.php
+++ b/serendipity_event_dsgvo_gdpr/lang_de.inc.php
@@ -124,3 +124,4 @@ Bestimmte Plugins können das Session-Cookie verwenden, um zusätzlich temporäre D
 @define('PLUGIN_EVENT_DSGVO_GDPR_BACKEND', 'Benutzerdaten verwalten');
 @define('PLUGIN_EVENT_DSGVO_GDPR_BACKEND_INFO', 'Hier können Sie einen exakt übereinstimmenden Benutzernamen oder eine E-Mail-Adresse eingeben, um diesen Benutzer zu entfernen oder seine Daten zu exportieren. Sie können mehrere Namen auf jeweils einer neuen Zeile eingeben.');
 @define('PLUGIN_EVENT_DSGVO_GDPR_BACKEND_DELFAIL', 'Um exportieren oder löschen zu können muss mindestens ein Benutzername oder eine E-Mail-Adresse eingegeben werden.');
+@define('PLUGIN_EVENT_DSGVO_GDPR_COPY_CLIPBOARD', 'In Zwischenablage kopieren');

--- a/serendipity_event_dsgvo_gdpr/lang_en.inc.php
+++ b/serendipity_event_dsgvo_gdpr/lang_en.inc.php
@@ -126,3 +126,4 @@ Certain plugins can use the session cookie to store additional temporary data.</
 @define('PLUGIN_EVENT_DSGVO_GDPR_BACKEND', 'Manage user data');
 @define('PLUGIN_EVENT_DSGVO_GDPR_BACKEND_INFO', 'Here you can enter an exactly matching username or e-mail address to remove or export data for that user. You can separate multiple names with a newline.');
 @define('PLUGIN_EVENT_DSGVO_GDPR_BACKEND_DELFAIL', 'To export or delete data you must specify at least one username or e-mail address.');
+@define('PLUGIN_EVENT_DSGVO_GDPR_COPY_CLIPBOARD', 'Copy to clipboard');

--- a/serendipity_event_dsgvo_gdpr/serendipity_event_dsgvo_gdpr.php
+++ b/serendipity_event_dsgvo_gdpr/serendipity_event_dsgvo_gdpr.php
@@ -23,7 +23,7 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
         $propbag->add('description',   PLUGIN_EVENT_DSGVO_GDPR_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Serendipity Team');
-        $propbag->add('version', '1.0.6');
+        $propbag->add('version', '1.1.1');
         $propbag->add('requirements',  array(
             'serendipity' => '2.0',
             'smarty'      => '2.6.7',
@@ -88,7 +88,7 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
                 $propbag->add('type','boolean');
                 $propbag->add('name', PLUGIN_EVENT_DSGVO_GDPR_COMMENTFORM_CHECKBOX);
                 $propbag->add('description', PLUGIN_EVENT_DSGVO_GDPR_COMMENTFORM_CHECKBOX_DESC);
-                $propbag->add('default', 'true');
+                $propbag->add('default', 'false');
                 break;
 
             case 'anonymizeIp':
@@ -116,7 +116,7 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
                 $propbag->add('type',        'content');
                 $propbag->add('name',        PLUGIN_EVENT_DSGVO_GDPR_INFO);
                 $propbag->add('description', PLUGIN_EVENT_DSGVO_GDPR_INFO_DESC);
-                $propbag->add('default',     $this->inspect_gdpr());
+                $propbag->add('default',     $this->inspect_gdpr() . $this->buttonCopyToClipboard($this->inspect_gdpr()));
                 break;
 
             case 'cookie_consent':
@@ -291,17 +291,17 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
                 if ($theme == $serendipity['template']) {
                     $pointer = 'theme_active';
 
-                    $$pointer .= '<h3>Active Theme "' . $theme .  '"</h3>';
+                    $$pointer .= '<h3>Active Theme "' . $theme .  '"</h3>' . "\n";
                 } else {
                     $pointer = 'theme_other';
 
-                    $$pointer .= '<h3>Available Theme "' . $theme .  '"</h3>';
+                    $$pointer .= '<h3>Available Theme "' . $theme .  '"</h3>' . "\n";
                 }
 
                 $$pointer .= '<ul>';
                 if (isset($static_info[$theme])) {
                     foreach($static_info[$theme] AS $themeout) {
-                        $$pointer .= '<li>' . $themeout . '</li>';
+                        $$pointer .= '<li>' . $themeout . "</li>\n";
                     }
                 }
 
@@ -346,6 +346,22 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
             if (empty($part)) continue;
             $out[] = "'" . serendipity_db_escape_string($part) . "'";
         }
+        return $out;
+    }
+
+    // outputs html for a button that copies the given text to the browser clipboard
+    function buttonCopyToClipboard($text) {
+        $out = '<textarea style="display: none;white-space: pre;" id="copyWrapper">' . serendipity_specialchars($text) . '</textarea>';
+        $out .= '<button type="button" onclick="copyTextFromWrapper()">Copy to Clipboard</button>';
+        $out .= '<script>
+            function copyTextFromWrapper() {
+                var target = document.getElementById("copyWrapper");
+                target.style.display = "block";
+                target.focus();
+                target.select();
+                document.execCommand("Copy");
+                target.style.display = "none";
+            }</script>';
         return $out;
     }
 

--- a/serendipity_event_dsgvo_gdpr/serendipity_event_dsgvo_gdpr.php
+++ b/serendipity_event_dsgvo_gdpr/serendipity_event_dsgvo_gdpr.php
@@ -23,7 +23,7 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
         $propbag->add('description',   PLUGIN_EVENT_DSGVO_GDPR_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Serendipity Team');
-        $propbag->add('version', '1.1.1');
+        $propbag->add('version', '1.2.0');
         $propbag->add('requirements',  array(
             'serendipity' => '2.0',
             'smarty'      => '2.6.7',
@@ -352,7 +352,7 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
     // outputs html for a button that copies the given text to the browser clipboard
     function buttonCopyToClipboard($text) {
         $out = '<textarea style="display: none;white-space: pre;" id="copyWrapper">' . serendipity_specialchars($text) . '</textarea>';
-        $out .= '<button type="button" onclick="copyTextFromWrapper()">Copy to Clipboard</button>';
+        $out .= '<button type="button" onclick="copyTextFromWrapper()">' . PLUGIN_EVENT_DSGVO_GDPR_COPY_CLIPBOARD . '</button>';
         $out .= '<script>
             function copyTextFromWrapper() {
                 var target = document.getElementById("copyWrapper");


### PR DESCRIPTION
I was annoyed when having to recreate the markup of the privacy notice draft. This adds a button that copies the html fro ma textarea into the clipboard, making it easy for the user to set the draft as his privacy notice. 

It also adds some newlines to the themes section to make it easier to edit that part.