### PR TITLE
Reset 404 error message for external PHP plugin

### DIFF
--- a/serendipity_event_externalphp/serendipity_event_externalphp.php
+++ b/serendipity_event_externalphp/serendipity_event_externalphp.php
@@ -83,6 +83,9 @@ class serendipity_event_externalphp extends serendipity_event {
         global $serendipity;
 
         if ($this->selected()) {
+            
+            $serendipity['content_message'] = ''; // Reset message for 404 error handling which is now overriden
+            
             if (!headers_sent()) {
                 header('HTTP/1.0 200');
                 header('Status: 200 OK');


### PR DESCRIPTION
Just like the static pages plugin the external PHP plugin overrides the 404 error handling. The content from the external PHP script is displayed as expected but above this content the error message from the language constant URL_NOT_FOUND is shown. The static pages plugin resets this error message to get rid of the error message. The change in this commit does exactly the same thing for the external PHP plugin.