### PR TITLE
Avoid calling displayEntry() if there is nothing to display.

### DIFF
--- a/serendipity_event_freetag/serendipity_event_freetag.php
+++ b/serendipity_event_freetag/serendipity_event_freetag.php
@@ -1295,6 +1295,7 @@ addLoadEvent(enableAutocomplete);
                     } else {
                         if (serendipity_db_bool($this->get_config('send_http_header', true))) {
                             @header('X-FreeTag-Count: Empty');
+                            return true;
                         }
                         $this->TaggedEntries = 0;
                     }


### PR DESCRIPTION
I noticed a PHP warning in my logs in the freetag plugin:
```
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in [path]/plugins/serendipity_event_freetag/serendipity_event_freetag.php on line 1349
```

Looking into this I figured out that this is in the function displayEntry which expects an array as a parameter. It gets called from a switch/case statement for 'entry_display' where it first checks if the param is actually an array or not. However displayEntry gets called unconditionally. I think this is the right fix, but please review it, I'm now returning early if there are no entries to display.