### PR TITLE
INCLUDE_ANY should be an array index, not a constant

### DIFF
--- a/serendipity_event_staticpage/serendipity_event_staticpage.php
+++ b/serendipity_event_staticpage/serendipity_event_staticpage.php
@@ -1287,10 +1287,10 @@ class serendipity_event_staticpage extends serendipity_event
         if (!$tfile || $tfile == $filename) {
             $tfile = dirname(__FILE__) . '/' . $filename;
         }
-        $inclusion = $serendipity['smarty']->security_settings[INCLUDE_ANY];
-        $serendipity['smarty']->security_settings[INCLUDE_ANY] = true;
+        $inclusion = $serendipity['smarty']->security_settings['INCLUDE_ANY'];
+        $serendipity['smarty']->security_settings['INCLUDE_ANY'] = true;
         $content = $serendipity['smarty']->fetch('file:'. $tfile);
-        $serendipity['smarty']->security_settings[INCLUDE_ANY] = $inclusion;
+        $serendipity['smarty']->security_settings['INCLUDE_ANY'] = $inclusion;
 
         return $content;
     }
@@ -2557,8 +2557,8 @@ foreach($select AS $select_value => $select_desc) {
                     $tfile = dirname(__FILE__) . '/backend_templates/' . $filename;
                 }
             }
-            $inclusion = $serendipity['smarty']->security_settings[INCLUDE_ANY];
-            $serendipity['smarty']->security_settings[INCLUDE_ANY] = true;
+            $inclusion = $serendipity['smarty']->security_settings['INCLUDE_ANY'];
+            $serendipity['smarty']->security_settings['INCLUDE_ANY'] = true;
             $serendipity['smarty']->assign(
                 array(
                     'showmeta'       => serendipity_db_bool($this->get_config('showmeta')),
@@ -2570,7 +2570,7 @@ foreach($select AS $select_value => $select_desc) {
                 )
             );
             $content = $serendipity['smarty']->fetch('file:'. $tfile);
-            $serendipity['smarty']->security_settings[INCLUDE_ANY] = $inclusion;
+            $serendipity['smarty']->security_settings['INCLUDE_ANY'] = $inclusion;
 
             echo $content;
             return true;


### PR DESCRIPTION
I found several warnings like this in my logs:
```
PHP Warning:  Use of undefined constant INCLUDE_ANY - assumed 'INCLUDE_ANY' (this will throw an Error in a future version of PHP) in [path]/plugins/serendipity_event_staticpage/serendipity_event_staticpage.php on line 2560
```

For all I can tell INCLUDE_ANY is actually meant to be an array index and not a constant. (However I'm not sure what it does, maybe this is just obsolete, there were other such code pieces in the past, but this is the only one left, and a comment in template_api.inc.php indicates $security_settings is unused.)