### PR TITLE
Cookie Consent: "understood", not "accepted".

### DIFF
--- a/serendipity_event_dsgvo_gdpr/lang_de.inc.php
+++ b/serendipity_event_dsgvo_gdpr/lang_de.inc.php
@@ -44,7 +44,7 @@ window.cookieconsent.initialise({
   },
   "content": {
     "message": "Diese Website verwendet Cookies.",
-    "dismiss": "Akzeptieren",
+    "dismiss": "Verstanden",
     "link": "Lesen Sie mehr in der Datenschutzerklärung",
     "href": "%gdpr_url%"
   }

--- a/serendipity_event_dsgvo_gdpr/lang_en.inc.php
+++ b/serendipity_event_dsgvo_gdpr/lang_en.inc.php
@@ -45,7 +45,7 @@ window.cookieconsent.initialise({
   },
   "content": {
     "message": "This website uses cookies.",
-    "dismiss": "I accept",
+    "dismiss": "I understand",
     "link": "Read more in the privacy statement",
     "href": "%gdpr_url%"
   }


### PR DESCRIPTION
The cookie consent banner is a notice to inform users about our usage of cookies - it's not a way to get consent, because cookies are used whether you click "accepted" or not. The click will just dismiss the banner.

As we do not really ask for consent - if we did, we had to refrain from setting cookies unless and until the users has accepted -, we shouldn't make it sound like we do. Anything else would IMO violate the GDPR requirement of "information [...] in a concise, transparent, intelligible and easily accessible form, using clear and plain language" (Art. 12).

So, "I understand" (or "dismiss") instead of "I accept".

Incidentally, I do not think that we need explicit consent for the usage of cookies to the extent that we do so. However, if we should need consent for legal reasons, then we must implement this in such a way that no cookies are set without consent.

Signed-off-by: Thomas Hochstein <thh@inter.net>