### PR TITLE
assign lang stripped blogTitle in genpage hook

### DIFF
--- a/serendipity_event_multilingual/ChangeLog
+++ b/serendipity_event_multilingual/ChangeLog
@@ -1,3 +1,4 @@
+2.35: assign lang stripped blogTitle in genpage hook (empty search was not covered)
 2.34: Added legal gdpr/dsgvo info
 2.33: Iconfont a11y fix (yellowled)
 

--- a/serendipity_event_multilingual/serendipity_event_multilingual.php
+++ b/serendipity_event_multilingual/serendipity_event_multilingual.php
@@ -27,7 +27,7 @@ class serendipity_event_multilingual extends serendipity_event
             'php'         => '4.1.0'
         ));
         $propbag->add('groups',         array('FRONTEND_ENTRY_RELATED', 'BACKEND_EDITOR'));
-        $propbag->add('version',        '2.34');
+        $propbag->add('version',        '2.35');
         $propbag->add('configuration',  array('copytext', 'placement', 'tagged_title', 'tagged_entries', 'tagged_sidebar', 'langswitch'));
         $propbag->add('event_hooks',    array(
                 'frontend_fetchentries'     => true,
@@ -475,11 +475,9 @@ class serendipity_event_multilingual extends serendipity_event
                     $serendipity['blogTitle'] = $this->strip_langs($serendipity['blogTitle']);
                     $serendipity['blogDescription'] = $this->strip_langs($serendipity['blogDescription']);
 
-                    // assign lang stripped blogTitle to archive page, which overwrites them for case archive pages
-                    if ($serendipity['plugindata']['smartyvars']['view'] == 'archive') {
-                        $serendipity['smarty']->assign('blogTitle', $serendipity['blogTitle']);
-                        $serendipity['smarty']->assign('blogDescription', $serendipity['blogDescription']);
-                    }
+                    // assign lang stripped blogTitle to all generated pages (empty search pages aren't processed otherwise)
+                    $serendipity['smarty']->assign('blogTitle', $serendipity['blogTitle']);
+                    $serendipity['smarty']->assign('blogDescription', $serendipity['blogDescription']);
 
                     if (!defined('Smarty::SMARTY_VERSION')) {
                         $this->tag_title(); // in Smarty 2 only


### PR DESCRIPTION
 empty search was no covered and showed the blog title and description in the {{  }} format unprocessed