### PR TITLE
[event_dsgvo_gdpr] Display plugin legal info.

### DIFF
--- a/serendipity_event_dsgvo_gdpr/ChangeLog
+++ b/serendipity_event_dsgvo_gdpr/ChangeLog
@@ -1,3 +1,4 @@
+1.2.1: Really display legal information for plugins.
 1.2.0: Add button to copy pricvacy draft in html
 1.1.0: Set default value of commentform checkbox to false
 1.0.7: Properly quit once the CSV dump is sent, and not embed this in HTML 

--- a/serendipity_event_dsgvo_gdpr/serendipity_event_dsgvo_gdpr.php
+++ b/serendipity_event_dsgvo_gdpr/serendipity_event_dsgvo_gdpr.php
@@ -23,7 +23,7 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
         $propbag->add('description',   PLUGIN_EVENT_DSGVO_GDPR_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Serendipity Team');
-        $propbag->add('version', '1.2.0');
+        $propbag->add('version', '1.2.1');
         $propbag->add('requirements',  array(
             'serendipity' => '2.0',
             'smarty'      => '2.6.7',
@@ -152,8 +152,7 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
 
         $classes = serendipity_plugin_api::enum_plugins();
         foreach ($classes as $class_data) {
-            $pluginFile =  serendipity_plugin_api::probePlugin($class_data['name'], $class_data['classname'], $class_data['pluginPath']);
-            $plugin     =& serendipity_plugin_api::getPluginInfo($pluginFile, $class_data, 'event');
+            $plugin =& serendipity_plugin_api::load_plugin($class_data['name']);
 
             if (is_object($plugin)) {
                 // Object is returned when a plugin could not be cached.
@@ -162,7 +161,7 @@ class serendipity_event_dsgvo_gdpr extends serendipity_event
 
                 $legal = $bag->get('legal');
                 if (is_array($legal)) {
-                    $out .= '<h3>' . $class_data['classname'] . '</h3>';
+                    $out .= '<h3>' . $bag->get('name') . '</h3>';
 
                     // "services" should list every service that a plugin connects to via a HTTP or other API interface,
                     // and describe what each service does, and which data it gets.


### PR DESCRIPTION
Currently, legal information for plugins is only shown when it had not been cached. As most plugin info will be cached, nothing's shown.

We have to bypass the cache and query all installed plugins directly to make that work.

Fixes s9y/Serendipity#572.

Signed-off-by: Thomas Hochstein <thh@inter.net>