### PR TITLE
[markdown] Make blockquotes in comments usable.

### DIFF
--- a/serendipity_event_markdown/ChangeLog
+++ b/serendipity_event_markdown/ChangeLog
@@ -1,3 +1,10 @@
+Version 1.27:
+=============
+Changes by Thomas Hochstein <thh@inter.net>
+
+- Undo replacing of ">" (by "&gt;"), done by serendipity_event_unstrip_tags,
+  at the beginning of the line in comments to make blockquotes possible.
+
 Version 1.26:
 =============
 Changes by Thomas Hochstein <thh@inter.net>

--- a/serendipity_event_markdown/serendipity_event_markdown.php
+++ b/serendipity_event_markdown/serendipity_event_markdown.php
@@ -31,7 +31,7 @@ class serendipity_event_markdown extends serendipity_event
             'smarty'      => '2.6.7',
             'php'         => '5.3.0'
         ));
-        $propbag->add('version',       '1.26');
+        $propbag->add('version',       '1.27');
         $propbag->add('cachable_events', array('frontend_display' => true));
         $propbag->add('event_hooks',   array(
             'frontend_display' => true,
@@ -175,6 +175,14 @@ class serendipity_event_markdown extends serendipity_event
                             !$eventData['properties']['ep_disable_markup_' . $this->instance] &&
                             !isset($serendipity['POST']['properties']['disable_markup_' . $this->instance])) {
                             $element = $temp['element'];
+                            # HTML special chars like ">" in comments may have been replaced by entities ("&gt;")
+                            # by serendipity_event_unstrip_tags; we have to - partially - undo that, as ">" is
+                            # used for blockquotes in Markdown.
+                            # The regexp will only match "&gt;" preceded by the start of the line or another "&gt;",
+                            # both optionally followed by whitespace.-
+                            if ($element == 'comment') {
+                              $eventData[$element] = preg_replace('/(^|(?<=&gt;))\s*&gt;/m', '>', $eventData[$element]);
+                            }
                             if ($mdv == 2) {
                                 if ($mde) {
                                     $parser = new MarkdownExtra;


### PR DESCRIPTION
Undo replacing of ">" (by "&gt;"), done by serendipity_event_unstrip_tags, at the beginning of the line in comments to make blockquotes possible.

Signed-off-by: Thomas Hochstein <thh@inter.net>