### PR TITLE
set xmlns for sitemap-news also with gnews_single mode

### DIFF
--- a/serendipity_event_google_sitemap/serendipity_event_google_sitemap.php
+++ b/serendipity_event_google_sitemap/serendipity_event_google_sitemap.php
@@ -592,20 +592,8 @@ class serendipity_event_google_sitemap extends serendipity_event {
     function write_sitemap($basefilename = 'sitemap.xml', &$eventData, $gnewsmode = false) {
         global $serendipity;
 
-        // start the xml
-        $sitemap_xml  = '<?xml version="1.0" encoding="UTF-8"?>'."\n";
-        $sitemap_xml .= "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"\n";
-        $sitemap_xml .= "\txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n";
-        if ($gnewsmode) {
-            $sitemap_xml .= "\txmlns:news=\"http://www.google.com/schemas/sitemap-news/0.9\"\n";                    
-        }
-        $sitemap_xml .= "\txsi:schemaLocation=\"http://www.sitemaps.org/schemas/sitemap/0.9\n";
-        $sitemap_xml .= "\t\t\thttp://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd\" ";
-        $sitemap_xml .= $this->get_config('custom2');
-        $sitemap_xml .= ">\n";
-
         $this->gnewsmode = false;
-        
+
         // If this variable is enabled, each XML article will get its gnews:... counterpart.
         // This is NOT desired in the usual sitemap!
         if ($gnewsmode) {
@@ -613,6 +601,19 @@ class serendipity_event_google_sitemap extends serendipity_event {
         } elseif (serendipity_db_bool($this->get_config('gnews_single')) && serendipity_db_bool($this->get_config('gnews'))) {
             $this->gnewsmode = true;
         }
+
+        // start the xml
+        $sitemap_xml  = '<?xml version="1.0" encoding="UTF-8"?>'."\n";
+        $sitemap_xml .= "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"\n";
+        $sitemap_xml .= "\txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n";
+        if ($this->gnewsmode) {
+            $sitemap_xml .= "\txmlns:news=\"http://www.google.com/schemas/sitemap-news/0.9\"\n";                    
+        }
+        $sitemap_xml .= "\txsi:schemaLocation=\"http://www.sitemaps.org/schemas/sitemap/0.9\n";
+        $sitemap_xml .= "\t\t\thttp://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd\" ";
+        $sitemap_xml .= $this->get_config('custom2');
+        $sitemap_xml .= ">\n";
+
 
 
         // add link to the main page


### PR DESCRIPTION
This should fix the errors I reported here:
https://board.s9y.org/viewtopic.php?f=3&t=24196

The problem in the code is this: The sitemap xmlns was included conditionally if $gnewsmode is set. However that is only the case for the separate gnews sitemap.
In the case of gnews_single - where the news items are included in the main sitemap - it's not. But it is still required.

There's a check for that and it sets $this->gnewsmode, but after that block, so I had to switch those code blocks around and change the if($gnewsmode) to if($this->gnewsmode).

Please merge.