### PR TITLE
Catch wrong last_modified dates.

### DIFF
--- a/serendipity_event_entrylastmodified/serendipity_event_entrylastmodified.php
+++ b/serendipity_event_entrylastmodified/serendipity_event_entrylastmodified.php
@@ -23,7 +23,7 @@ class serendipity_event_entrylastmodified extends serendipity_event {
         $propbag->add('description',   PLUGIN_EVENT_ENTRYLASTMODIFIED_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Garvin Hicking');
-        $propbag->add('version',       '1.9.1');
+        $propbag->add('version',       '1.10');
         $propbag->add('requirements',  array(
             'serendipity' => '0.8',
             'smarty'      => '2.6.7',
@@ -99,7 +99,8 @@ class serendipity_event_entrylastmodified extends serendipity_event {
                     $extended_key = &$this->getFieldReference('extended', $eventData);
                     if ($addData['extended'] || $addData['preview']) {
                         $eventData[0]['exflag'] = 1;
-                        if ($eventData[0]['timestamp'] != $eventData[0]['last_modified']) {
+                        # 631152000 is 01.01.1990 00:00:00 GMT - earlier timestamps must be wrong
+                        if ($eventData[0]['timestamp'] != $eventData[0]['last_modified'] && $eventData[0]['last_modified'] > 631152000) {
                             $lm = sprintf($format_string_mod, $position, PLUGIN_EVENT_ENTRYLASTMODIFIED_HTML, serendipity_formatTime(DATE_FORMAT_SHORT, $eventData[0]['last_modified']));
                             $eventData[0]['add_footer'] .= $lm;
                             $eventData[0]['string_last_modified'] .= $lm;


### PR DESCRIPTION
My database has some last_modified entries just containing the year (2004, as it is) or "0", leading to wrong "last modified" dates in January, 1970 (2004) or displaying the current date and time for "last modified". A simple check can catch those wrong entries, as there can't be any valid modification dates before 1990 (not even after an import from some older blog software).

I *could* fix my database instead, but I'm not sure of the reason for those entries; they may be artifacts of my initial import into s9y or from older plugin or s9y versions. This sanity check doesn't hurt, I think.

Signed-off-by: Thomas Hochstein <thh@inter.net>