### PR TITLE
metadesc: Fix logic for INSERT/UPDATE/DELETE.

### DIFF
--- a/serendipity_event_metadesc/ChangeLog
+++ b/serendipity_event_metadesc/ChangeLog
@@ -1,3 +1,7 @@
+0.15.4:
+-------
+  * Fix logic for INSERT/UPDATE/DELETE of properties.
+
 0.15.3:
 -------
   * Fixed access to $entry some more. :)

--- a/serendipity_event_metadesc/serendipity_event_metadesc.php
+++ b/serendipity_event_metadesc/serendipity_event_metadesc.php
@@ -25,7 +25,7 @@ class serendipity_event_metadesc extends serendipity_event {
         $propbag->add('description',   PLUGIN_METADESC_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Garvin Hicking, Judebert, Don Chambers');
-        $propbag->add('version',       '0.15.3');
+        $propbag->add('version',       '0.15.4');
         $propbag->add('requirements',  array(
             'serendipity' => '0.8',
             'php'         => '4.1.0'
@@ -242,8 +242,10 @@ class serendipity_event_metadesc extends serendipity_event {
                             $q = "INSERT INTO {$serendipity['dbPrefix']}entryproperties (entryid, property, value) VALUES (" . (int)$eventData['id'] . ", '" . serendipity_db_escape_string($prop_key) . "', '" . serendipity_db_escape_string($prop_val) . "')";
                         } elseif ($property[$propkey] != $prop_val && !empty($prop_val)) {
                             $q = "UPDATE {$serendipity['dbPrefix']}entryproperties SET value = '" . serendipity_db_escape_string($prop_val) . "' WHERE entryid = " . (int)$eventData['id'] . " AND property = '" . serendipity_db_escape_string($prop_key) . "'";
-                        } else {
+                        } elseif (!empty($property[$prop_key] && empty($prop_val)) {
                             $q = "DELETE FROM {$serendipity['dbPrefix']}entryproperties WHERE entryid = " . (int)$eventData['id'] . " AND property = '" . serendipity_db_escape_string($prop_key) . "'";
+                        } else {
+                          // nothing to do
                         }
 
                         serendipity_db_query($q);


### PR DESCRIPTION
Properties where deleted from the database when the property was present in the database and it wasn't changed. That seems wrong.

A property should only be deleted if it is set in the database, but not set in the POST request.

Signed-off-by: Thomas Hochstein <thh@inter.net>