### PR TITLE
emerge_spartacus: remove netmirror upload.

### DIFF
--- a/emerge_spartacus.php
+++ b/emerge_spartacus.php
@@ -455,6 +455,8 @@ class emerge_spartacus {
     }
 
     function upload($file, $remotefile) {
+        # netmirror.org is no longer functional nor is it used
+        return;
         static $c, $login;
         if (function_exists('ftp_connect')) {
             if (!is_resource($c) || !$login) {


### PR DESCRIPTION
netmirror.org is no longer used in spartacus.
FTP connects fail anyway.

Signed-off-by: Thomas Hochstein <thh@inter.net>