### PR TITLE
metadesc: Rellay fix INSERT/UPDATE/DELETE logic.

### DIFF
--- a/serendipity_event_metadesc/ChangeLog
+++ b/serendipity_event_metadesc/ChangeLog
@@ -1,5 +1,5 @@
-0.15.4:
--------
+0.15.4 & 0.15.5:
+----------------
   * Fix logic for INSERT/UPDATE/DELETE of properties.
 
 0.15.3:

--- a/serendipity_event_metadesc/serendipity_event_metadesc.php
+++ b/serendipity_event_metadesc/serendipity_event_metadesc.php
@@ -25,7 +25,7 @@ class serendipity_event_metadesc extends serendipity_event {
         $propbag->add('description',   PLUGIN_METADESC_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Garvin Hicking, Judebert, Don Chambers');
-        $propbag->add('version',       '0.15.4');
+        $propbag->add('version',       '0.15.5');
         $propbag->add('requirements',  array(
             'serendipity' => '0.8',
             'php'         => '4.1.0'
@@ -245,10 +245,11 @@ class serendipity_event_metadesc extends serendipity_event {
                         } elseif (!empty($property[$prop_key]) && empty($prop_val)) {
                             $q = "DELETE FROM {$serendipity['dbPrefix']}entryproperties WHERE entryid = " . (int)$eventData['id'] . " AND property = '" . serendipity_db_escape_string($prop_key) . "'";
                         } else {
-                          // nothing to do
+                            // nothing to do
+                            $q = '';
                         }
 
-                        serendipity_db_query($q);
+                        if (!empty($q)) serendipity_db_query($q);
                     }
 
                     return true;


### PR DESCRIPTION
8155626bd66604dc9097b83b98a44ff772acbec6 will lead to empty db queries if all properties are unchanged.

Fix that.

Signed-off-by: Thomas Hochstein <thh@inter.net>