### PR TITLE
[event_autoupdate] Add option to disable file integrity checks

### DIFF
--- a/serendipity_event_autoupdate/ChangeLog
+++ b/serendipity_event_autoupdate/ChangeLog
@@ -1,3 +1,6 @@
+1.1.9: Add config setting 'disable_integrity_checks' to disable file integrity
+       checks for one run (see https://board.s9y.org/viewtopic.php?f=1&t=24492)
+
 1.1.8: Iconfont a11y fix (yellowled)
 
 1.1.7: Fix beta-version upgrade by using github-archive path and making the

--- a/serendipity_event_autoupdate/UTF-8/lang_de.inc.php
+++ b/serendipity_event_autoupdate/UTF-8/lang_de.inc.php
@@ -1,7 +1,13 @@
 <?php
 
-@define('PLUGIN_EVENT_AUTOUPDATE_NAME',     'Serendipity Autoupdate');
-@define('PLUGIN_EVENT_AUTOUPDATE_DESC',     'Sobald das Dashboard Plugin (einmal am Tag) ein Serendipity Update entdeckt, setzt dieses Plugin eine Ein-Klick Option in das Dashboard des Backends, um ein manuelles Download oder ein automatisches und gesichertes Upgrade der Blogsoftware zu starten.');
-@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON',     'Automatisches Upgrade starten');
-
-?>
+@define('PLUGIN_EVENT_AUTOUPDATE_NAME', 'Serendipity Autoupdate');
+@define(
+    'PLUGIN_EVENT_AUTOUPDATE_DESC',
+    'Sobald das Dashboard Plugin (einmal am Tag) ein Serendipity Update entdeckt, setzt dieses Plugin eine Ein-Klick Option in das Dashboard des Backends, um ein manuelles Download oder ein automatisches und gesichertes Upgrade der Blogsoftware zu starten.'
+);
+@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON', 'Automatisches Upgrade starten');
+@define('PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS', 'Deaktiviere Integritätsprüfung (ACHTUNG!)');
+@define(
+    'PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS_DESC',
+    'Diese Einstellung deaktiviert die Integritätsprüfung für Dateien für einen Durchlauf des automatischen Updates. Sie wird danach automatisch wieder auf `Nein` gesetzt.'
+);

--- a/serendipity_event_autoupdate/UTF-8/lang_de.inc.php
+++ b/serendipity_event_autoupdate/UTF-8/lang_de.inc.php
@@ -1,13 +1,14 @@
 <?php
 
-@define('PLUGIN_EVENT_AUTOUPDATE_NAME', 'Serendipity Autoupdate');
-@define(
-    'PLUGIN_EVENT_AUTOUPDATE_DESC',
-    'Sobald das Dashboard Plugin (einmal am Tag) ein Serendipity Update entdeckt, setzt dieses Plugin eine Ein-Klick Option in das Dashboard des Backends, um ein manuelles Download oder ein automatisches und gesichertes Upgrade der Blogsoftware zu starten.'
-);
-@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON', 'Automatisches Upgrade starten');
+@define('PLUGIN_EVENT_AUTOUPDATE_NAME',     'Serendipity Autoupdate');
+@define('PLUGIN_EVENT_AUTOUPDATE_DESC',     'Sobald das Dashboard Plugin (einmal am Tag) ein Serendipity Update entdeckt, setzt dieses Plugin eine Ein-Klick Option in das Dashboard des Backends, um ein manuelles Download oder ein automatisches und gesichertes Upgrade der Blogsoftware zu starten.');
+@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON',     'Automatisches Upgrade starten');
 @define('PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS', 'Deaktiviere Integritätsprüfung (ACHTUNG!)');
 @define(
     'PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS_DESC',
     'Diese Einstellung deaktiviert die Integritätsprüfung für Dateien für einen Durchlauf des automatischen Updates. Sie wird danach automatisch wieder auf `Nein` gesetzt.'
+);
+@define(
+    'PLUGIN_EVENT_AUTOUPDATE_RETRY_NO_INTEGRITY_CHECKS_BUTTON',
+    'Automatisches Upgrade ohne Integritätsprüfung wiederholen'
 );

--- a/serendipity_event_autoupdate/UTF-8/lang_en.inc.php
+++ b/serendipity_event_autoupdate/UTF-8/lang_en.inc.php
@@ -1,7 +1,13 @@
 <?php
 
-@define('PLUGIN_EVENT_AUTOUPDATE_NAME',     'Serendipity Autoupdate');
-@define('PLUGIN_EVENT_AUTOUPDATE_DESC',     'When the dashboard-plugin (once a day) detects an update, this plugin adds the option to manually download or start an automatic and secured upgrade of the blog directly with one click from within the adminarea.');
-@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON',     'Start automatic upgrade');
-
-?>
+@define('PLUGIN_EVENT_AUTOUPDATE_NAME', 'Serendipity Autoupdate');
+@define(
+    'PLUGIN_EVENT_AUTOUPDATE_DESC',
+    'When the dashboard-plugin (once a day) detects an update, this plugin adds the option to manually download or start an automatic and secured upgrade of the blog directly with one click from within the adminarea.'
+);
+@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON', 'Start automatic upgrade');
+@define('PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS', 'Disable integrity checks (CAUTION!)');
+@define(
+    'PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS_DESC',
+    'This setting disables the file integrity checks for one run of the auto updater. It will be automatically reset to `No` after the update.'
+);

--- a/serendipity_event_autoupdate/UTF-8/lang_en.inc.php
+++ b/serendipity_event_autoupdate/UTF-8/lang_en.inc.php
@@ -1,13 +1,14 @@
 <?php
 
-@define('PLUGIN_EVENT_AUTOUPDATE_NAME', 'Serendipity Autoupdate');
-@define(
-    'PLUGIN_EVENT_AUTOUPDATE_DESC',
-    'When the dashboard-plugin (once a day) detects an update, this plugin adds the option to manually download or start an automatic and secured upgrade of the blog directly with one click from within the adminarea.'
-);
-@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON', 'Start automatic upgrade');
+@define('PLUGIN_EVENT_AUTOUPDATE_NAME',     'Serendipity Autoupdate');
+@define('PLUGIN_EVENT_AUTOUPDATE_DESC',     'When the dashboard-plugin (once a day) detects an update, this plugin adds the option to manually download or start an automatic and secured upgrade of the blog directly with one click from within the adminarea.');
+@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON',     'Start automatic upgrade');
 @define('PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS', 'Disable integrity checks (CAUTION!)');
 @define(
     'PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS_DESC',
     'This setting disables the file integrity checks for one run of the auto updater. It will be automatically reset to `No` after the update.'
+);
+@define(
+    'PLUGIN_EVENT_AUTOUPDATE_RETRY_NO_INTEGRITY_CHECKS_BUTTON',
+    'Retry automatic upgrade with integrity checks disabled'
 );

--- a/serendipity_event_autoupdate/lang_de.inc.php
+++ b/serendipity_event_autoupdate/lang_de.inc.php
@@ -8,3 +8,7 @@
     'PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS_DESC',
     'Diese Einstellung deaktiviert die Integritätsprüfung für Dateien für einen Durchlauf des automatischen Updates. Sie wird danach automatisch wieder auf `Nein` gesetzt.'
 );
+@define(
+    'PLUGIN_EVENT_AUTOUPDATE_RETRY_NO_INTEGRITY_CHECKS_BUTTON',
+    'Automatisches Upgrade ohne Integritätsprüfung wiederholen'
+);

--- a/serendipity_event_autoupdate/lang_de.inc.php
+++ b/serendipity_event_autoupdate/lang_de.inc.php
@@ -3,5 +3,8 @@
 @define('PLUGIN_EVENT_AUTOUPDATE_NAME',     'Serendipity Autoupdate');
 @define('PLUGIN_EVENT_AUTOUPDATE_DESC',     'Sobald das Dashboard Plugin (einmal am Tag) ein Serendipity Update entdeckt, setzt dieses Plugin eine Ein-Klick Option in das Dashboard des Backends, um ein manuelles Download oder ein automatisches und gesichertes Upgrade der Blogsoftware zu starten.');
 @define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON',     'Automatisches Upgrade starten');
-
-?>
+@define('PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS', 'Deaktiviere Integritätsprüfung (ACHTUNG!)');
+@define(
+    'PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS_DESC',
+    'Diese Einstellung deaktiviert die Integritätsprüfung für Dateien für einen Durchlauf des automatischen Updates. Sie wird danach automatisch wieder auf `Nein` gesetzt.'
+);

--- a/serendipity_event_autoupdate/lang_en.inc.php
+++ b/serendipity_event_autoupdate/lang_en.inc.php
@@ -1,7 +1,13 @@
 <?php
 
-@define('PLUGIN_EVENT_AUTOUPDATE_NAME',     'Serendipity Autoupdate');
-@define('PLUGIN_EVENT_AUTOUPDATE_DESC',     'When the dashboard-plugin (once a day) detects an update, this plugin adds the option to manually download or start an automatic and secured upgrade of the blog directly with one click from within the adminarea.');
-@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON',     'Start automatic upgrade');
-
-?>
+@define('PLUGIN_EVENT_AUTOUPDATE_NAME', 'Serendipity Autoupdate');
+@define(
+    'PLUGIN_EVENT_AUTOUPDATE_DESC',
+    'When the dashboard-plugin (once a day) detects an update, this plugin adds the option to manually download or start an automatic and secured upgrade of the blog directly with one click from within the adminarea.'
+);
+@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON', 'Start automatic upgrade');
+@define('PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS', 'Disable integrity casdf hecks (CAUTION!)');
+@define(
+    'PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS_DESC',
+    'This setting disables the file integrity checks for one run of the auto updater. It will be automatically reset to `No` after the update.'
+);

--- a/serendipity_event_autoupdate/lang_en.inc.php
+++ b/serendipity_event_autoupdate/lang_en.inc.php
@@ -1,13 +1,14 @@
 <?php
 
-@define('PLUGIN_EVENT_AUTOUPDATE_NAME', 'Serendipity Autoupdate');
-@define(
-    'PLUGIN_EVENT_AUTOUPDATE_DESC',
-    'When the dashboard-plugin (once a day) detects an update, this plugin adds the option to manually download or start an automatic and secured upgrade of the blog directly with one click from within the adminarea.'
-);
-@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON', 'Start automatic upgrade');
+@define('PLUGIN_EVENT_AUTOUPDATE_NAME',     'Serendipity Autoupdate');
+@define('PLUGIN_EVENT_AUTOUPDATE_DESC',     'When the dashboard-plugin (once a day) detects an update, this plugin adds the option to manually download or start an automatic and secured upgrade of the blog directly with one click from within the adminarea.');
+@define('PLUGIN_EVENT_AUTOUPDATE_UPDATEBUTTON',     'Start automatic upgrade');
 @define('PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS', 'Disable integrity casdf hecks (CAUTION!)');
 @define(
     'PLUGIN_EVENT_AUTOUPDATE_DISABLE_INTEGRITY_CHECKS_DESC',
     'This setting disables the file integrity checks for one run of the auto updater. It will be automatically reset to `No` after the update.'
+);
+@define(
+    'PLUGIN_EVENT_AUTOUPDATE_RETRY_NO_INTEGRITY_CHECKS_BUTTON',
+    'Retry automatic upgrade with integrity checks disabled'
 );

--- a/serendipity_event_autoupdate/serendipity_event_autoupdate.php
+++ b/serendipity_event_autoupdate/serendipity_event_autoupdate.php
@@ -579,7 +579,6 @@ EOS;
      */
     function checkIntegrity($version) {
         global $serendipity;
-        return false;
 
         $updateDir    = (string)$serendipity['serendipityPath'] . 'templates_c/' . "serendipity-$version/";
         $checksumFile = (string)$updateDir . "serendipity/checksums.inc.php";


### PR DESCRIPTION
Add an option to the plugin settings that allows to disable the file integrity checks _for one run_ of the auto updater. The option is reset immediately to ensure the file integrity checks are performed the next time the auto updater is run.

So if anyone experiences the issue linked below, we can point them to this option.

Addresses [this issue](https://board.s9y.org/viewtopic.php?f=1&t=24492&sid=797753f16261c7ed4fe71f252c0de1ce).