### PR TITLE
Fix some long dead links, enhance language chooser.

### DIFF
--- a/homepage/index.php
+++ b/homepage/index.php
@@ -11,6 +11,12 @@ if (is_dir('homepage')) {
 } else {
     define('BASEDIR', '');
 }
+if (!empty($_REQUEST['mode']) && (substr(($_REQUEST['mode']), 0, 8) != 'template')) {
+    $page_language = end(explode('_',$_REQUEST['mode']));
+    if ($page_language != LANG) { 
+        $_REQUEST['mode'] = preg_replace ('/'.$page_language.'$/', LANG, $_REQUEST['mode']);
+    }           
+}
 ?>
 <!DOCTYPE html>
 <html class="no-js" lang="en">
@@ -128,6 +134,7 @@ if (is_dir('homepage')) {
                     <h3>Change language</h3>
 
                     <form action="index.php" method="get">
+                        <input type="hidden" name="mode" value="<?php echo $_REQUEST['mode']; ?>">
                         <select class="language" name="language">
                     <?php
                         $lang = array('en' => 'English',

--- a/homepage/index.php
+++ b/homepage/index.php
@@ -186,7 +186,7 @@ if (is_dir('homepage')) {
                 <li><a href="https://blog.s9y.org/index.php?serendipity[subpage]=dsgvo_gdpr_privacy">Privacy policy</a></li>
             </ul>
 
-            <p id="supporters">This site is hosted by the kind people at <a href="http://www.sourceforge.net">SourceForge.net</a> and created by <a href="http://garv.in">Garvin Hicking</a>.</p>
+            <p id="supporters">This site is hosted at <a href="https://uberspace.de/">Uberspace</a> and created by <a href="http://garv.in">Garvin Hicking</a> and the Serendipity Project.</p>
         </div>
     </footer>
 

--- a/homepage/index.php
+++ b/homepage/index.php
@@ -169,8 +169,8 @@ if (is_dir('homepage')) {
                     <h3>Feeds</h3>
 
                     <ul>
-                        <li><a href="http://www.netmirror.org/mirror/serendipity/package_RSSevent.xml">Event plugins</a></li>
-                        <li><a href="http://www.netmirror.org/mirror/serendipity/package_RSSsidebar.xml">Sidebar plugins</a></li>
+                        <li><a href="https://raw.githubusercontent.com/s9y/additional_plugins/master/package_RSSevent.xml">Event plugins</a></li>
+                        <li><a href="https://raw.githubusercontent.com/s9y/additional_plugins/master/package_RSSsidebar.xml">Sidebar plugins</a></li>
                         <li><a href="https://github.com/s9y/additional_plugins/commits/master.atom">Plugin commits</a></li>
                         <li><a href="https://github.com/s9y/additional_themes/commits/master.atom">Theme commits</a></li>
                     </ul>

--- a/homepage/index.php
+++ b/homepage/index.php
@@ -183,7 +183,7 @@ if (is_dir('homepage')) {
         <div class="layout-container">
             <ul id="service-links">
                 <li><a id="to-top" href="#top">Back to top</a></li>
-                <li><a href="http://jann.is/datenschutz.html">Privacy policy</a></li>
+                <li><a href="https://blog.s9y.org/index.php?serendipity[subpage]=dsgvo_gdpr_privacy">Privacy policy</a></li>
             </ul>
 
             <p id="supporters">This site is hosted by the kind people at <a href="http://www.sourceforge.net">SourceForge.net</a> and created by <a href="http://garv.in">Garvin Hicking</a>.</p>


### PR DESCRIPTION
* RSS feed links to netmirror are long dead; use Github instead.
* The linked privacy policy is gone, too. Use the same page as everywhere else.
* We are not hosted by SourceForge any longer.
* Keep currently selected page when changing language, but change language for that page on the fly.

Signed-off-by: Thomas Hochstein <thh@inter.net>