### PR TITLE
[event_social] Set social media image for entry.

### DIFF
--- a/serendipity_event_social/ChangeLog
+++ b/serendipity_event_social/ChangeLog
@@ -1,3 +1,6 @@
+0.14
+    * Add per-entry social media image.
+
 0.13.2
     * Remove Google+ (shutdown 2019-04-02)
 

--- a/serendipity_event_social/UTF-8/lang_de.inc.php
+++ b/serendipity_event_social/UTF-8/lang_de.inc.php
@@ -17,4 +17,6 @@
 @define('PLUGIN_EVENT_SOCIAL_BACKEND', 'Backend für Zähler');
 @define('PLUGIN_EVENT_SOCIAL_BACKEND_DESC', 'URL für ein Shariff-Backend, mit dem einige der Buttons (u.a. Facebook) anzeigen wie oft der Artikel geteilt wurde. "none" deaktiviert den Zähler. Standard: "https://onli.columba.uberspace.de/s9y_shariff"');
 @define('PLUGIN_EVENT_SOCIAL_IMAGE', 'Fallback-Bild');
-@define('PLUGIN_EVENT_SOCIAL_IMAGE_DESC', 'Ein Bild, das auf Twitter und Facebook angezeigt wird wenn der Eintrag kein eigenes Bild erhält. "none" deaktiviert es.');
+@define('PLUGIN_EVENT_SOCIAL_IMAGE_DESC', 'Ein Bild, das auf Twitter und Facebook angezeigt wird, wenn der Eintrag kein eigenes Bild erhält. "none" deaktiviert es.');
+@define('PLUGIN_EVENT_SOCIAL_ENTRY_IMAGE', 'Bild für Social Media');
+

--- a/serendipity_event_social/UTF-8/lang_en.inc.php
+++ b/serendipity_event_social/UTF-8/lang_en.inc.php
@@ -18,3 +18,4 @@
 @define('PLUGIN_EVENT_SOCIAL_BACKEND_DESC', 'URL to a shariff backend, that provides some buttons (like Facebook) with a share counter. Set to "none" to deacivate. Default: "https://onli.columba.uberspace.de/s9y_shariff"');
 @define('PLUGIN_EVENT_SOCIAL_IMAGE', 'Fallback Image');
 @define('PLUGIN_EVENT_SOCIAL_IMAGE_DESC', 'Image shown on Twitter and Facebok if the entry contains no own image. Set to "none" to deacivate.');
+@define('PLUGIN_EVENT_SOCIAL_ENTRY_IMAGE', 'Image shown on Social-Media');

--- a/serendipity_event_social/lang_de.inc.php
+++ b/serendipity_event_social/lang_de.inc.php
@@ -17,4 +17,5 @@
 @define('PLUGIN_EVENT_SOCIAL_BACKEND', 'Backend für Zähler');
 @define('PLUGIN_EVENT_SOCIAL_BACKEND_DESC', 'URL für ein Shariff-Backend, mit dem einige der Buttons (u.a. Facebook) anzeigen wie oft der Artikel geteilt wurde. "none" deaktiviert den Zähler. Standard: "https://onli.columba.uberspace.de/s9y_shariff"');
 @define('PLUGIN_EVENT_SOCIAL_IMAGE', 'Fallback-Bild');
-@define('PLUGIN_EVENT_SOCIAL_IMAGE_DESC', 'Ein Bild, das auf Twitter und Facebook angezeigt wird wenn der Eintrag kein eigenes Bild erhält. "none" deaktiviert es.');
+@define('PLUGIN_EVENT_SOCIAL_IMAGE_DESC', 'Ein Bild, das auf Twitter und Facebook angezeigt wird, wenn der Eintrag kein eigenes Bild erhält. "none" deaktiviert es.');
+@define('PLUGIN_EVENT_SOCIAL_ENTRY_IMAGE', 'Bild für Social Media');

--- a/serendipity_event_social/lang_en.inc.php
+++ b/serendipity_event_social/lang_en.inc.php
@@ -18,3 +18,4 @@
 @define('PLUGIN_EVENT_SOCIAL_BACKEND_DESC', 'URL to a shariff backend, that provides some buttons (like Facebook) with a share counter. Set to "none" to deacivate. Default: "https://onli.columba.uberspace.de/s9y_shariff"');
 @define('PLUGIN_EVENT_SOCIAL_IMAGE', 'Fallback Image');
 @define('PLUGIN_EVENT_SOCIAL_IMAGE_DESC', 'Image shown on Twitter and Facebok if the entry contains no own image. Set to "none" to deacivate.');
+@define('PLUGIN_EVENT_SOCIAL_ENTRY_IMAGE', 'Image shown on Social-Media');


### PR DESCRIPTION
_event_social_ will use the first image from the entry for the OpenGrahp "og:image" meta property used by Facebook and Twitter; if there is none, it will fall back to the default image from the plugin configuration. The timeline and photo themes support setting a featured image that is used instead.

Add the possibility to set a social media image for each entry, regardless of theme. If there is none set, fall back to timeline or photo featured images, or the first image in the entry body, or the default image from the plugin configuration (in that order).

Signed-off-by: Thomas Hochstein <thh@inter.net>