### PR TITLE
substitute break outside of a loop by `return false`

### DIFF
--- a/serendipity_event_podcast/ChangeLog
+++ b/serendipity_event_podcast/ChangeLog
@@ -1,4 +1,10 @@
 # 
+1.37.4:
+
+    * substitute break outside of a loop by `return false`
+      PHP 7 doesn't accept `break` statements outside of loop or switch structures and
+      returns an error. See https://www.php.net/manual/en/control-structures.break.php
+
 1.37.3: Fixed bad constand name "DDEFAULT" to "DEFAULT"
 
 1.37.2:

--- a/serendipity_event_podcast/player/getid3/getid3.lib.php
+++ b/serendipity_event_podcast/player/getid3/getid3.lib.php
@@ -278,7 +278,7 @@ class getid3_lib
 				}
 			} else {
 				throw new Exception('ERROR: Cannot have signed integers larger than '.(8 * PHP_INT_SIZE).'-bits ('.strlen($byteword).') in getid3_lib::BigEndian2Int()');
-				break;
+				return false;
 			}
 		}
 		return getid3_lib::CastAsInt($intvalue);

--- a/serendipity_event_podcast/serendipity_event_podcast.php
+++ b/serendipity_event_podcast/serendipity_event_podcast.php
@@ -14,7 +14,7 @@ if (file_exists($probelang)) {
 include_once dirname(__FILE__) . '/lang_en.inc.php';
 include_once dirname(__FILE__) . '/podcast_player.php';
 
-@define("SERENDIPITY_EVENT_PODCAST_VERSION", "1.37.3");
+@define("SERENDIPITY_EVENT_PODCAST_VERSION", "1.37.4");
 
 class serendipity_event_podcast extends serendipity_event {
 /**


### PR DESCRIPTION
PHP 7 doesn't accept `break` statements outside of loop or switch structures and
returns an error. See https://www.php.net/manual/en/control-structures.break.php
I substituted the `break` by a `return false` which as far as I assume does the same.