### PR TITLE
freetag: Fix typo, cond instead of ccond, avoids undefined var error

### DIFF
--- a/serendipity_event_freetag/serendipity_event_freetag.php
+++ b/serendipity_event_freetag/serendipity_event_freetag.php
@@ -1572,7 +1572,7 @@ addLoadEvent(enableAutocomplete);
             } else if (is_array($tag)) {
                  $join = "LEFT JOIN {$serendipity['dbPrefix']}entrytags AS neg ".
                     "ON main.entryid = neg.entryid ";
-                $ccond = '';
+                $cond = '';
                 $ncond = '';
 
                 $first = true;

--- a/serendipity_event_freetag/serendipity_event_freetag.php
+++ b/serendipity_event_freetag/serendipity_event_freetag.php
@@ -770,7 +770,7 @@ class serendipity_event_freetag extends serendipity_event
                                 $param = array_map('urldecode', $param); // for doubled encoded tag umlauts via searchengines backlinks in sprintf
                             }
                             $param = array_map('strip_tags', $param);
-                            $param = array_filter($param); // empty removed XSS by strip_tags
+                            $param = array_values(array_filter($param)); // empty removed XSS by strip_tags
                             if (function_exists('serendipity_specialchars')) {
                                 $serendipity['head_subtitle'] = sprintf(PLUGIN_EVENT_FREETAG_USING, implode(' + ', array_map('serendipity_specialchars', $param)));
                             } else {

--- a/serendipity_event_freetag/serendipity_event_freetag.php
+++ b/serendipity_event_freetag/serendipity_event_freetag.php
@@ -66,7 +66,7 @@ class serendipity_event_freetag extends serendipity_event
             'smarty'      => '2.6.7',
             'php'         => '7.0'
         ));
-        $propbag->add('version',       '3.70.4');
+        $propbag->add('version',       '3.70.5');
         $propbag->add('event_hooks',    array(
             'frontend_fetchentries'                             => true,
             'frontend_fetchentry'                               => true,


### PR DESCRIPTION
I got a warning about an undefined variable $cond in serendipity_event_freetag.php.

This looks like it's just a typo. Through a loop various things are appended via "$cond .= ..." and at the beginning $ccond is set to an empty string. $ccond isn't used anywhere else. It was probably intended here to set $cond to an empty string instead of $ccond.