### PR TITLE
imagesidebar 0.100.3: Fix permanent display of unknown mime icon

### DIFF
--- a/serendipity_plugin_imagesidebar/ChangeLog
+++ b/serendipity_plugin_imagesidebar/ChangeLog
@@ -1,3 +1,7 @@
+0.100.3:
+-----
+    * Fix image display when fetching from ML
+    
 0.100.2:
 -----
     * Hotfixes for PHP 8 (surrim)

--- a/serendipity_plugin_imagesidebar/media_sidebar.php
+++ b/serendipity_plugin_imagesidebar/media_sidebar.php
@@ -232,6 +232,7 @@ class media_sidebar extends subplug_sidebar {
             if (is_array($images)) {
                 $output_str .= $this->get_config('media_intro');
                 foreach ($images as $image) {
+                    serendipity_prepareMedia($image);
                     if (isset($image['name'])) {
                         if ($image['hotlink'] == 1) {
                             $thumb_path = $image_path = $image['path'];

--- a/serendipity_plugin_imagesidebar/serendipity_plugin_imagesidebar.php
+++ b/serendipity_plugin_imagesidebar/serendipity_plugin_imagesidebar.php
@@ -68,7 +68,7 @@ class serendipity_plugin_imagesidebar extends serendipity_plugin {
         $propbag->add('description',   PLUGIN_SIDEBAR_IMAGESIDEBAR_DESC);
         $propbag->add('stackable',     true);
         $propbag->add('author',        'Andrew Brown (Menalto code), Matthew Groeninger (Unified/Media Lib. Code), Stefan Lange-Hegermann (Zooomr Code), Matthew Maude (Coppermine code)');
-        $propbag->add('version',       '0.100.2');
+        $propbag->add('version',       '0.100.3');
         $propbag->add('license',       'BSD');
         $propbag->add('requirements',  array(
             'serendipity' => '0.8',


### PR DESCRIPTION
Fixes the plugin for s9y 2.4 (and it still works in 2.3.5)