### PR TITLE
Check that the tag GET variable is a string

### DIFF
--- a/serendipity_event_freetag/serendipity_event_freetag.php
+++ b/serendipity_event_freetag/serendipity_event_freetag.php
@@ -66,7 +66,7 @@ class serendipity_event_freetag extends serendipity_event
             'smarty'      => '2.6.7',
             'php'         => '7.0'
         ));
-        $propbag->add('version',       '3.70.5');
+        $propbag->add('version',       '3.70.6');
         $propbag->add('event_hooks',    array(
             'frontend_fetchentries'                             => true,
             'frontend_fetchentry'                               => true,
@@ -1170,7 +1170,7 @@ addLoadEvent(enableAutocomplete);
                         } else {
                             $showtag = serendipity_db_escape_string($this->tags['show']);
                         }
-                    } else if (!empty($serendipity['GET']['tag'])) {
+                    } else if (!empty($serendipity['GET']['tag']) && is_string($serendipity['GET']['tag'])) {
                         $showtag = serendipity_db_escape_string(urldecode($serendipity['GET']['tag']));
                     }
 


### PR DESCRIPTION
By sending a tag variable that is an array one can trigger an uncaught exception. I saw these in my logs, likely due to some internet scans.

This can be reproduced like this:
```
curl 'https://[host]/rss.php?serendipity\[tag\]\[\]=1'
```

Fixing this by checking that the var is actually a string, and ignore it otherwise.