### PR TITLE
Fix blank admin page with PHP8

### DIFF
--- a/serendipity_plugin_topexits/ChangeLog
+++ b/serendipity_plugin_topexits/ChangeLog
@@ -1,0 +1,3 @@
+1.2:
+---
+ * Fixed blank admin page with PHP8

--- a/serendipity_plugin_topexits/UTF-8/lang_en.inc.php
+++ b/serendipity_plugin_topexits/UTF-8/lang_en.inc.php
@@ -1,0 +1,4 @@
+<?php
+@define('TOP_EXITS',                        'Top Exits');
+@define('SHOWS_TOP_EXIT',                   'Shows the most common exit urls');
+?>

--- a/serendipity_plugin_topexits/serendipity_plugin_topexits.php
+++ b/serendipity_plugin_topexits/serendipity_plugin_topexits.php
@@ -1,5 +1,11 @@
 <?php
 
+if (IN_serendipity !== true) {
+    die ("Don't hack!");
+}
+
+@serendipity_plugin_api::load_language(dirname(__FILE__));
+
 class serendipity_plugin_topexits extends serendipity_plugin {
     var $title = TOP_EXITS;
 
@@ -9,7 +15,7 @@ class serendipity_plugin_topexits extends serendipity_plugin {
         $propbag->add('description',   SHOWS_TOP_EXIT);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Serendipity Team');
-        $propbag->add('version',       '1.1');
+        $propbag->add('version',       '1.2');
         $propbag->add('configuration', array('limit', 'use_links', 'interval'));
         $propbag->add('groups',        array('STATISTICS'));
     }


### PR DESCRIPTION
Add missing TOP_EXITS and SHOWS_TOP_EXIT string definitions that
lead to a blank serendipity_admin.php page under PHP 8.
See https://board.s9y.org/viewtopic.php?t=25730

Also add the IN_serendipity check, and ChangeLog.
