### PR TITLE
Fix broken admin page with PHP8

### DIFF
--- a/serendipity_event_statistics/ChangeLog
+++ b/serendipity_event_statistics/ChangeLog
@@ -1,3 +1,4 @@
+1.66: Fixed broken admin page with PHP8
 1.65: Added legal gdpr/dsgvo info
 1.63: Restrict sql index key length for utf8mb4 migration
 1.62: Iconfont a11y fix (yellowled)

--- a/serendipity_event_statistics/lang_en.inc.php
+++ b/serendipity_event_statistics/lang_en.inc.php
@@ -104,3 +104,6 @@
 
 @define('PLUGIN_EVENT_STATISTICS_SHOW_CURRENTVISITORS', 'Show number of current visitors (aggregate past 15 minutes)');
 @define('PLUGIN_EVENT_STATISTICS_TEXT_CURRENTVISITORS', '%s visitor(s) online');
+
+@define('PLUGIN_EVENT_STATISTICS_TOP_REFERRER', 'Top Referrers');
+@define('PLUGIN_EVENT_STATISTICS_TOP_EXITS', 'Top Exits');

--- a/serendipity_event_statistics/serendipity_event_statistics.php
+++ b/serendipity_event_statistics/serendipity_event_statistics.php
@@ -16,7 +16,7 @@ class serendipity_event_statistics extends serendipity_event
         $propbag->add('description',   PLUGIN_EVENT_STATISTICS_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Arnan de Gans, Garvin Hicking, Fredrik Sandberg, kalkin, Matthias Mees, Ian');
-        $propbag->add('version',       '1.65');
+        $propbag->add('version',       '1.66');
         $propbag->add('requirements',  array(
             'serendipity' => '1.6',
             'smarty'      => '2.6.7',
@@ -600,13 +600,13 @@ class serendipity_event_statistics extends serendipity_event
         </section>
 
         <section>
-            <h3><?php echo TOP_REFERRER; ?></h3>
+            <h3><?php echo PLUGIN_EVENT_STATISTICS_TOP_REFERRER; ?></h3>
 
             <?php echo serendipity_displayTopReferrers($max_items, true); ?>
         </section>
 
         <section>
-            <h3><?php echo TOP_EXITS; ?></h3>
+            <h3><?php echo PLUGIN_EVENT_STATISTICS_TOP_EXITS; ?></h3>
 
             <?php echo serendipity_displayTopExits($max_items, true); ?>
         </section>


### PR DESCRIPTION
Undefined language constants TOP_REFERRER and TOP_EXITS lead to
uncaught error, apparently assumed to be available via
serendipity_plugin_entrylinks.

Create and use proper PLUGIN_EVENT_STATISTICS_TOP_REFERRER and
PLUGIN_EVENT_STATISTICS_TOP_EXITS constants.
