### PR TITLE
Check is_countable() before count()

### DIFF
--- a/serendipity_event_linktrimmer/ChangeLog
+++ b/serendipity_event_linktrimmer/ChangeLog
@@ -1,3 +1,5 @@
+1.6.6: Check is_countable() before count()
+
 1.6.5: Hotfixes for PHP 8 (surrim)
 
 1.6.4: Added German translation.

--- a/serendipity_event_linktrimmer/serendipity_event_linktrimmer.php
+++ b/serendipity_event_linktrimmer/serendipity_event_linktrimmer.php
@@ -6,6 +6,16 @@ if (IN_serendipity !== true) {
 
 @serendipity_plugin_api::load_language(dirname(__FILE__));
 
+if (PHP_VERSION_ID < 70300) {
+    // Borrowed from
+    // https://github.com/symfony/polyfill/blob/6b0f6d1b248ec4adc9bb18f4a93b30cc9788713a/src/Php73/bootstrap.php#L18
+    if (!function_exists('is_countable')) {
+        function is_countable($value) {
+            return is_array($value) || $value instanceof Countable || $value instanceof ResourceBundle || $value instanceof SimpleXmlElement;
+        }
+    }
+}
+
 class serendipity_event_linktrimmer extends serendipity_event {
     var $debug;
 
@@ -20,7 +30,7 @@ class serendipity_event_linktrimmer extends serendipity_event {
             'php'         => '4.1.0'
         ));
 
-        $propbag->add('version',       '1.6.5');
+        $propbag->add('version',       '1.6.6');
         $propbag->add('author',        'Garvin Hicking, Ian');
         $propbag->add('stackable',     false);
         $propbag->add('configuration', array('prefix', 'frontpage', 'domain'));
@@ -320,7 +330,7 @@ class serendipity_event_linktrimmer extends serendipity_event {
                     $uri_part = $parts[0];
                     $parts = array_pop($parts);
 
-                    if (count($parts) > 1) {
+                    if (is_countable($parts) && count($parts) > 1) {
                        foreach($parts as $key => $value) {
                             $val = explode('=', $value);
                             $_REQUEST[$val[0]] = $val[1];
@@ -332,7 +342,7 @@ class serendipity_event_linktrimmer extends serendipity_event {
 
                     if (!isset($_REQUEST['txtarea'])) {
                         $parts = explode('&', $uri_parts[1]);
-                        if (count($parts) > 1) {
+                        if (is_countable($parts) && count($parts) > 1) {
                             foreach($parts as $key => $value) {
                                  $val = explode('=', $value);
                                  $_REQUEST[$val[0]] = $val[1];


### PR DESCRIPTION
is_countable() would demand PHP >= 7.3.0 as of which it is available.
See https://www.php.net/manual/en/function.is-countable.php
Use a polyfill for PHP < 7.3.0

Loading serendipity_admin.php with $serendipity['production'] = false
yielded a red alert box:

The Serendipity JavaScript-library could not be loaded. This can happen
due to PHP or Plugin errors, or even a malformed browser cache. To check
the exact error please open
https://.../index.php?/plugin/admin/serendipity_editor.js manually in
your browser and check for error messages.

Where at the end of that file could be found:

== ERROR-REPORT (BETA/ALPHA-BUILDS) ==
<p><b>Warning:</b> count(): Parameter must be an array or an object that
implements Countable in
plugins/serendipity_event_linktrimmer/serendipity_event_linktrimmer.php
on line 323.</p>
