### PR TITLE
serendipity_event_geshi: fix warning when $eventData contains no properties

### DIFF
--- a/serendipity_event_geshi/ChangeLog
+++ b/serendipity_event_geshi/ChangeLog
@@ -1,3 +1,7 @@
+1.1,2:
+-----
+ * Fix warnings in aricles without any properties (mitch)
+
 1.1.1:
 -----
  * Hotfixes for PHP 8 (surrim)

--- a/serendipity_event_geshi/serendipity_event_geshi.php
+++ b/serendipity_event_geshi/serendipity_event_geshi.php
@@ -74,7 +74,7 @@ class serendipity_event_geshi extends serendipity_event
             'smarty'      => '2.6.7',
             'php'         => '7.0'
         ));
-        $propbag->add('version',       '1.1.1');
+        $propbag->add('version',       '1.1.2');
         $propbag->add('event_hooks', array('frontend_display' => true, 'frontend_comment' => true));
         $propbag->add('groups', array('MARKUP'));
 
@@ -150,7 +150,7 @@ class serendipity_event_geshi extends serendipity_event
                 case 'frontend_display':
                     foreach ($this->markup_elements as $temp) {
                         if (serendipity_db_bool($this->get_config($temp['name'], true)) && isset($eventData[$temp['element']]) &&
-                            !$eventData['properties']['ep_disable_markup_' . $this->instance] &&
+                            !(isset($eventData['properties']['ep_disable_markup_' . $this->instance]) && $eventData['properties']['ep_disable_markup_' . $this->instance]) &&
                             !isset($serendipity['POST']['properties']['disable_markup_' . $this->instance])) {
                             $element = $temp['element'];
                             $eventData[$element] = $this->geshi($eventData[$element]);


### PR DESCRIPTION
* Serendipity 2.4.0
* serendipity_event_geshi 1.1.1

Some of my blog entries don't seem to have any _properties_ and produced warnings in the HTTP server log like these:

```
[Wed Jul 12 22:33:30.225879 2023] [php:warn] [pid 517606] [client […]] PHP Warning:  Trying to access array offset on value of type null in […]/plugins/serendipity_event_geshi/serendipity_event_geshi.php on line 153, referer: […]
[Wed Jul 12 22:33:31.617569 2023] [php:warn] [pid 517606] [client […]] PHP Warning:  Undefined array key "propertie..s" in […]/plugins/serendipity_event_geshi/serendipity_event_geshi.php on line 153, referer: […]
```

Adding `isset()` to the referenced line of code fixes the warnings for me.
My Geshi code blocks still render as before.