### PR TITLE
spambayes: make tokens case-sensitive on MySQL

### DIFF
--- a/serendipity_event_spamblock_bayes/serendipity_event_spamblock_bayes.php
+++ b/serendipity_event_spamblock_bayes/serendipity_event_spamblock_bayes.php
@@ -102,6 +102,8 @@ class serendipity_event_spamblock_bayes extends serendipity_event {
                 serendipity_db_query($sql);
                 $sql = "INSERT IGNORE INTO b8_wordlist (token, count_ham, count_spam) VALUES ('b8*texts', 0, 0);";
                 serendipity_db_query($sql);
+                $sql = "ALTER TABLE b8_wordlist MODIFY COLUMN token varchar(255) COLLATE 'utf8mb4_bin';";
+                serendipity_db_query($sql);
                 
                 # our recycler bin needs to copy the comments table
                 $sql = "CREATE TABLE IF NOT EXISTS


### PR DESCRIPTION
Alter the token column in the b8_wordlist to a case-sensitive collation to prevent duplicate key errors when the same token is encountered in different cases (e.g. 'the', 'THE' and 'ThE').

The PHP code compares tokens case-sensitive when deciding whether to do an INSERT or UPDATE, so the database also needs to be case-sensitive.

After finding out that the collation update fixes my primary key constraint violations, I've done these test steps to ensure the code change does indeed apply the collation update as desired:

1. I renamed my `b8_wordlist` table to `b8_wordlist_SAVE` (because I have no separate blog for testing, I had to use my live blog)
2. Calling the comments page in the administration ran the `setupDB()` function
3. The missing `b8_wordlist` table was recreated.
4. `SHOW FULL COLUMNS FROM b8_wordlist;` still showed the default collation `utf8mb4_unicode_ci` which is case-insensitive and yields errors.
5. Apply the code change from this commit
6. Refresh the comments page to re-run `setupDB()`
7. `SHOW FULL COLUMNS FROM b8_wordlist;` no shows the collation `utf8mb4_bin` as desired.
8. dopped the `b8_wordlist` (which was still empty and only created for testeing)
9. renamed `b8_wordlist_SAVE` back to `b8_wordlist` 
10. everything wors fine, my data is back and there are no problems running the `ALTER TABLE` statement again when it has already been applied once

This change fixes the same problem as https://gitlab.com/l3u/b8/-/commit/137d8d1db9943e934be894d2d4dc0aaffc1e239f from upstream b8 as @onli has established after I had found this fix for s9y.