### PR TITLE
fix author handle in changelog entry

### DIFF
--- a/serendipity_event_geshi/ChangeLog
+++ b/serendipity_event_geshi/ChangeLog
@@ -1,6 +1,6 @@
 1.1,2:
 -----
- * Fix warnings in aricles without any properties (mitch)
+ * Fix warnings in aricles without any properties (mmitch)
 
 1.1.1:
 -----


### PR DESCRIPTION
Use the GitHub handle as everybody else does.

@onli In your commit cf0c19255 you used my GitHub handle, so we should be doing the same here.
I don't think this needs a separate release of the plugin, it can wait until the next real change.