### PR TITLE
flickr 1.0: Restore functionality and make compatible with PHP 8

### DIFF
--- a/serendipity_event_flickr/ChangeLog
+++ b/serendipity_event_flickr/ChangeLog
@@ -1,3 +1,10 @@
+1.0:
+---
+    * Additional fixes for PHP 8
+    * Restore flickr import functionality
+    * Update used phpFlickr library. The new version no longer relies on HTTP_Request, and also
+      was not patched to rely on HTTP_Request 2. It instead calls curl or pfsockopen directly.
+
 0.6.1:
 ---
     * Hotfixes for PHP 8 (surrim)

--- a/serendipity_event_flickr/phpFlickr/phpFlickr.php
+++ b/serendipity_event_flickr/phpFlickr/phpFlickr.php
@@ -30,6 +30,7 @@ if ( !class_exists('phpFlickr') ) {
 		var $upload_endpoint = 'https://up.flickr.com/services/upload/';
 		var $replace_endpoint = 'https://up.flickr.com/services/replace/';
 		var $req;
+		var $cache_request;
 		var $response;
 		var $parsed_response;
 		var $cache = false;
@@ -43,6 +44,7 @@ if ( !class_exists('phpFlickr') ) {
 		var $error_code;
 		Var $error_msg;
 		var $token;
+		var $service;
 		var $php_version;
 		var $custom_post = null, $custom_cache_get = null, $custom_cache_set = null;
 
@@ -58,7 +60,7 @@ if ( !class_exists('phpFlickr') ) {
 		 */
 		var $max_cache_rows = 1000;
 
-		function phpFlickr ($api_key, $secret = NULL, $die_on_error = false) {
+		function __construct($api_key, $secret = NULL, $die_on_error = false) {
 			//The API Key must be set before any calls can be made.  You can
 			//get your own at https://www.flickr.com/services/api/misc.api_keys.html
 			$this->api_key = $api_key;
@@ -922,7 +924,7 @@ if ( !class_exists('phpFlickr') ) {
 		function people_findByUsername ($username) {
 			/* https://www.flickr.com/services/api/flickr.people.findByUsername.html */
 			$this->request("flickr.people.findByUsername", array("username"=>$username));
-			return $this->parsed_response ? $this->parsed_response['user'] : false;
+			return $this->parsed_response ? $this->parsed_response['user']['id'] : false;
 		}
 
 		function people_getInfo ($user_id) {

--- a/serendipity_event_flickr/phpFlickr/phpFlickr.php
+++ b/serendipity_event_flickr/phpFlickr/phpFlickr.php
@@ -1,1282 +1,1822 @@
 <?php
-/* phpFlickr Class 1.4.3
+/* phpFlickr
  * Written by Dan Coulter (dan@dancoulter.com)
- * Sourceforge Project Page: http://www.sourceforge.net/projects/phpflickr/
- * Released under GNU General Public License (http://www.gnu.org/copyleft/gpl.html)
- * For more information about the class and upcoming tools and toys using it,
- * visit http://www.phpflickr.com/ or http://phpflickr.sourceforge.net
+ * Project Home Page: http://github.com/dan-coulter/phpflickr
  *
- *     For installation instructions, open the README.txt file packaged with this
- *     class. If you don't have a copy, you can see it at:
- *     http://www.phpflickr.com/README.txt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- *     Please submit all problems or questions to the Help Forum on my project page:
- *         http://sourceforge.net/forum/forum.php?forum_id=469652
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-if (session_id() == "") {
-    session_start();
-}
-require_once(dirname(__FILE__).'/xml.php');
+if ( !class_exists('phpFlickr') ) {
+	if (session_id() == "") {
+		@session_start();
+	}
 
-// Decides which include path delimiter to use.  Windows should be using a semi-colon
-// and everything else should be using a colon.  If this isn't working on your system,
-// comment out this if statement and manually set the correct value into $path_delimiter.
-if (strpos(__FILE__, ':') !== false) {
-    $path_delimiter = ';';
-} else {
-    $path_delimiter = ':';
-}
+	class phpFlickr {
+		var $api_key;
+		var $secret;
 
-// This will add the packaged PEAR files into the include path for PHP, allowing you
-// to use them transparently.  This will prefer officially installed PEAR files if you
-// have them.  If you want to prefer the packaged files (there shouldn't be any reason
-// to), swap the two elements around the $path_delimiter variable.  If you don't have
-// the PEAR packages installed, you can leave this like it is and move on.
+		var $rest_endpoint = 'https://api.flickr.com/services/rest/';
+		var $upload_endpoint = 'https://up.flickr.com/services/upload/';
+		var $replace_endpoint = 'https://up.flickr.com/services/replace/';
+		var $req;
+		var $response;
+		var $parsed_response;
+		var $cache = false;
+		var $cache_db = null;
+		var $cache_table = null;
+		var $cache_dir = null;
+		var $cache_expire = null;
+		var $cache_key = null;
+		var $last_request = null;
+		var $die_on_error;
+		var $error_code;
+		Var $error_msg;
+		var $token;
+		var $php_version;
+		var $custom_post = null, $custom_cache_get = null, $custom_cache_set = null;
 
-// PATCH FOR SERENDIPITY. NOT NEEDED, PART OF SERENDIPITY BUNDLED-LIBS!
-// ini_set('include_path', ini_get('include_path') . $path_delimiter . dirname(__FILE__) . '/PEAR');
+		/*
+		 * When your database cache table hits this many rows, a cleanup
+		 * will occur to get rid of all of the old rows and cleanup the
+		 * garbage in the table.  For most personal apps, 1000 rows should
+		 * be more than enough.  If your site gets hit by a lot of traffic
+		 * or you have a lot of disk space to spare, bump this number up.
+		 * You should try to set it high enough that the cleanup only
+		 * happens every once in a while, so this will depend on the growth
+		 * of your table.
+		 */
+		var $max_cache_rows = 1000;
 
-// If you have problems including the default PEAR install (like if your open_basedir
-// setting doesn't allow you to include files outside of your web root), comment out
-// the line above and uncomment the next line:
+		function phpFlickr ($api_key, $secret = NULL, $die_on_error = false) {
+			//The API Key must be set before any calls can be made.  You can
+			//get your own at https://www.flickr.com/services/api/misc.api_keys.html
+			$this->api_key = $api_key;
+			$this->secret = $secret;
+			$this->die_on_error = $die_on_error;
+			$this->service = "flickr";
 
-//ini_set('include_path', dirname(__FILE__) . '/PEAR' . $path_delimiter . ini_get('include_path'));
+			//Find the PHP version and store it for future reference
+			$this->php_version = explode("-", phpversion());
+			$this->php_version = explode(".", $this->php_version[0]);
+		}
 
-class phpFlickr {
-    var $api_key;
-    var $secret;
-    var $REST = 'http://www.flickr.com/services/rest/';
-    var $Upload = 'http://www.flickr.com/services/upload/';
-    var $xml_parser;
-    var $req;
-    var $response;
-    var $parsed_response;
-    var $cache = false;
-    var $cache_db = null;
-    var $cache_table = null;
-    var $cache_dir = null;
-    var $cache_expire = null;
-    var $die_on_error;
-    var $error_code;
-    Var $error_msg;
-    var $token;
+		function enableCache ($type, $connection, $cache_expire = 600, $table = 'flickr_cache') {
+			// Turns on caching.  $type must be either "db" (for database caching) or "fs" (for filesystem).
+			// When using db, $connection must be a PEAR::DB connection string. Example:
+			//	  "mysql://user:password@server/database"
+			// If the $table, doesn't exist, it will attempt to create it.
+			// When using file system, caching, the $connection is the folder that the web server has write
+			// access to. Use absolute paths for best results.  Relative paths may have unexpected behavior
+			// when you include this.  They'll usually work, you'll just want to test them.
+			if ($type == 'db') {
+				if ( preg_match('|mysql://([^:]*):([^@]*)@([^/]*)/(.*)|', $connection, $matches) ) {
+					//Array ( [0] => mysql://user:password@server/database [1] => user [2] => password [3] => server [4] => database )
+					$db = mysqli_connect($matches[3],  $matches[1],  $matches[2]);
+					mysqli_query($db, "USE $matches[4]");
 
+					/*
+					 * If high performance is crucial, you can easily comment
+					 * out this query once you've created your database table.
+					 */
+					mysqli_query($db, "
+						CREATE TABLE IF NOT EXISTS `$table` (
+							`request` varchar(128) NOT NULL,
+							`response` mediumtext NOT NULL,
+							`expiration` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+							UNIQUE KEY `request` (`request`)
+						)
+					");
 
-    function __construct($api_key, $secret = NULL, $die_on_error = true)
-    {
-        //The API Key must be set before any calls can be made.  You can
-        //get your own at http://www.flickr.com/services/api/misc.api_keys.html
-        $this->api_key = $api_key;
-        $this->secret = $secret;
-        $this->die_on_error = $die_on_error;
+					$result = mysqli_query($db, "SELECT COUNT(*) 'count' FROM $table");
+					if( $result ) {
+						$result = mysqli_fetch_assoc($result);						
+					}
+					
+					if ( $result && $result['count'] > $this->max_cache_rows ) {
+						mysqli_query($db, "DELETE FROM $table WHERE CURRENT_TIMESTAMP > expiration");
+						mysqli_query($db, 'OPTIMIZE TABLE ' . $this->cache_table);
+					}
+					$this->cache = 'db';
+					$this->cache_db = $db;
+					$this->cache_table = $table;
+				}
+			} elseif ($type == 'fs') {
+				$this->cache = 'fs';
+				$connection = realpath($connection);
+				$this->cache_dir = $connection;
+				if ($dir = opendir($this->cache_dir)) {
+					while ($file = readdir($dir)) {
+						if (substr($file, -6) == '.cache' && ((filemtime($this->cache_dir . '/' . $file) + $cache_expire) < time()) ) {
+							unlink($this->cache_dir . '/' . $file);
+						}
+					}
+				}
+			} elseif ( $type == 'custom' ) {
+				$this->cache = "custom";
+				$this->custom_cache_get = $connection[0];
+				$this->custom_cache_set = $connection[1];
+			}
+			$this->cache_expire = $cache_expire;
+		}
 
-        //All calls to the API are done via the POST method using the PEAR::HTTP_Request package.
-        //SERENDIPITY PATCH
-        require_once S9Y_PEAR_PATH . 'HTTP/Request.php';
-        $this->req = new HTTP_Request();
-        $this->req->setMethod(HTTP_REQUEST_METHOD_POST);
-
-        //setup XML parser using Aaron Colflesh's XML class.
-        $this->xml_parser = new xml(false, true, true);
-    }
-
-    function enableCache($type, $connection, $cache_expire = 600, $table = 'flickr_cache')
-    {
-        // Turns on caching.  $type must be either "db" (for database caching) or "fs" (for filesystem).
-        // When using db, $connection must be a PEAR::DB connection string. Example:
-        //      "mysql://user:password@server/database"
-        // If the $table, doesn't exist, it will attempt to create it.
-        // When using file system, caching, the $connection is the folder that the web server has write
-        // access to. Use absolute paths for best results.  Relative paths may have unexpected behavior
-        // when you include this.  They'll usually work, you'll just want to test them.
-        if ($type == 'db') {
-            require_once 'DB.php';
-            $db =& DB::connect($connection);
-            if (PEAR::isError($db)) {
-                die($db->getMessage());
-            }
-
-            $db->query("
-                CREATE TABLE IF NOT EXISTS `$table` (
-                    `request` CHAR( 35 ) NOT NULL ,
-                    `response` TEXT NOT NULL ,
-                    `expiration` DATETIME NOT NULL ,
-                    INDEX ( `request` )
-                ) TYPE = MYISAM");
-            $db->query("DELETE FROM $table WHERE expiration < DATE_SUB(NOW(), INTERVAL $cache_expire second)");
-            if (strpos($connection, 'mysql') !== false) {
-                $db->query('OPTIMIZE TABLE ' . $table);
-            }
-            $this->cache = 'db';
-            $this->cache_db = $db;
-            $this->cache_table = $table;
-        } elseif ($type = 'fs') {
-            $this->cache = 'fs';
-            chdir($connection);
-            $this->cache_dir = getcwd();
-            if ($dir = opendir('./')) {
-                while ($file = readdir($dir)) {
-                    if (substr($file, -6) == '.cache' && ((filemtime($file) + $cache_expire) < time()) ) {
-                        unlink($file);
-                    }
-                }
-            }
-        }
-        $this->cache_expire = $cache_expire;
-    }
-
-    function getCached ($request)
-    {
-        //Checks the database or filesystem for a cached result to the request.
-        //If there is no cache result, it returns a value of false. If it finds one,
-        //it returns the unparsed XML.
-        $reqhash = md5(serialize($request));
-        if ($this->cache == 'db') {
-            $result = $this->cache_db->getOne("SELECT response FROM " . $this->cache_table . " WHERE request = '" . $reqhash . "'");
-            if (!empty($result)) {
-                return $result;
-            }
-        } elseif ($this->cache == 'fs') {
-            $file = $this->cache_dir . '/' . $reqhash . '.cache';
-            if (file_exists($file)) {
-                return file_get_contents($file);
-            }
-        }
-        return false;
-    }
-
-    function cache ($request, $response)
-    {
-        //Caches the unparsed XML of a request.
-        $reqhash = md5(serialize($request));
-        if ($this->cache == 'db') {
-            $this->cache_db->query("DELETE FROM $this->cache_table WHERE request = '$reqhash'");
-            $sql = "INSERT INTO " . $this->cache_table . " (request, response, expiration) VALUES ('$reqhash', '" . str_replace("'", "''", $response) . "', '" . strftime("%Y-%m-%d %H:%M:%S") . "')";
-            $this->cache_db->query($sql);
-        } elseif ($this->cache == "fs") {
-            $file = $this->cache_dir . "/" . $reqhash . ".cache";
-            $fstream = fopen($file, "w");
-            $result = fwrite($fstream,$response);
-            fclose($fstream);
-            return $result;
-        }
-        return false;
-    }
-
-    function request ($command, $args = array(), $nocache = false)
-    {
-        //Sends a request to Flickr's REST endpoint via POST.
-        $this->req->setURL($this->REST);
-        $this->req->clearPostData();
-        if (substr($command,0,7) != "flickr.") {
-            $command = "flickr." . $command;
-        }
-
-        //Process arguments, including method and login data.
-        $args = array_merge(array("method" => $command, "api_key" => $this->api_key), $args);
-        if (!empty($this->token)) {
-            $args = array_merge($args, array("auth_token" => $this->token));
-        } elseif (!empty($_SESSION['phpFlickr_auth_token'])) {
-            $args = array_merge($args, array("auth_token" => $_SESSION['phpFlickr_auth_token']));
-        }
-        ksort($args);
-        $auth_sig = "";
-        if (!($this->response = $this->getCached($args)) || $nocache) {
-            foreach ($args as $key => $data) {
-                $auth_sig .= $key . $data;
-                $this->req->addPostData($key, $data);
-            }
-            if (!empty($this->secret)) {
-                $api_sig = md5($this->secret . $auth_sig);
-                $this->req->addPostData("api_sig", $api_sig);
-            }
-
-            //Send Requests
-            if ($this->req->sendRequest()) {
-                $this->response = $this->req->getResponseBody();
-                $this->cache($args, $this->response);
-            } else {
-                die("There has been a problem sending your command to the server.");
-            }
-        }
-        return $this->response;
-    }
-
-    function parse_response ($xml = NULL)
-    {
-        //Sends response data through XML parser and returns an associative array.
-        if ($xml === NULL) {
-            $xml = $this->response;
-        }
-        $this->parsed_response = $this->xml_parser->parse($xml);
-
-        //Check for an error and die if it finds one.
-        if (!empty($this->parsed_response['rsp']['err']) && $this->die_on_error) {
-            die("The Flickr API returned error code #" . $this->parsed_response['rsp']['err']['code'] . ": " . $this->parsed_response['rsp']['err']['msg']);
-        } elseif (!empty($this->parsed_response['rsp']['err'])) {
-			$this->error_code = $this->parsed_response['rsp']['err']['code'];
-			$this->error_msg = "The Flickr API returned error code #" . $this->parsed_response['rsp']['err']['code'] . ": " . $this->parsed_response['rsp']['err']['msg'];
+		function getCached ($request)
+		{
+			//Checks the database or filesystem for a cached result to the request.
+			//If there is no cache result, it returns a value of false. If it finds one,
+			//it returns the unparsed XML.
+			unset($request['api_sig']);
+			foreach ( $request as $key => $value ) {
+				if ( empty($value) ) unset($request[$key]);
+				else $request[$key] = (string) $request[$key];
+			}
+			//if ( is_user_logged_in() ) print_r($request);
+			$reqhash = md5(serialize($request));
+			$this->cache_key = $reqhash;
+			$this->cache_request = $request;
+			if ($this->cache == 'db') {
+				$result = mysqli_query($this->cache_db, "SELECT response FROM " . $this->cache_table . " WHERE request = '" . $reqhash . "' AND CURRENT_TIMESTAMP < expiration");
+				if ( $result && mysqli_num_rows($result) ) {
+					$result = mysqli_fetch_assoc($result);
+					return urldecode($result['response']);
+				} else {
+					return false;
+				}
+			} elseif ($this->cache == 'fs') {
+				$file = $this->cache_dir . '/' . $reqhash . '.cache';
+				if (file_exists($file)) {
+					if ($this->php_version[0] > 4 || ($this->php_version[0] == 4 && $this->php_version[1] >= 3)) {
+						return file_get_contents($file);
+					} else {
+						return implode('', file($file));
+					}
+				}
+			} elseif ( $this->cache == 'custom' ) {
+				return call_user_func_array($this->custom_cache_get, array($reqhash));
+			}
 			return false;
-        } else {
-			$this->error_code = false;
-			$this->error_msg = false;
-        }
-
-        return $this->parsed_response['rsp'];
-    }
-
-    function setToken($token) {
-        // Sets an authentication token to use instead of the session variable
-        $this->token = $token;
-    }
-
-    function getErrorCode()
-    {
-		// Returns the error code of the last call.  If the last call did not
-		// return an error. This will return a false boolean.
-		return $this->error_code;
-    }
-
-    function getErrorMsg()
-    {
-		// Returns the error message of the last call.  If the last call did not
-		// return an error. This will return a false boolean.
-		return $this->error_msg;
-    }
-
-    /* These functions are front ends for the flickr calls */
-
-    function buildPhotoURL ($photo, $size = "Medium")
-    {
-        //receives an array (can use the individual photo data returned
-        //from an API call) and returns a URL (doesn't mean that the
-        //file size exists)
-        $url = "http://static.flickr.com/" . $photo['server'] . "/" . $photo['id'] . "_" . $photo['secret'];
-        switch (strtolower($size)) {
-            case "square":
-                $url .= "_s";
-                break;
-            case "thumbnail":
-                $url .= "_t";
-                break;
-            case "small":
-                $url .= "_m";
-                break;
-            case "medium":
-                $url .= "";
-                break;
-            case "large":
-                $url .= "_b";
-                break;
-            case "original":
-                $url .= "_o";
-                break;
-        }
-        $url .= ".jpg";
-        return $url;
-    }
-
-    function sync_upload ($photo, $title = null, $description = null, $tags = null, $is_public = null, $is_friend = null, $is_family = null) {
-        $this->req->setURL($this->Upload);
-        $this->req->clearPostData();
-
-        //Process arguments, including method and login data.
-        $args = array("api_key" => $this->api_key, "title" => $title, "description" => $description, "tags" => $tags, "is_public" => $is_public, "is_friend" => $is_friend, "is_family" => $is_family);
-        if (!empty($this->email)) {
-            $args = array_merge($args, array("email" => $this->email));
-        }
-        if (!empty($this->password)) {
-            $args = array_merge($args, array("password" => $this->password));
-        }
-        if (!empty($this->token)) {
-            $args = array_merge($args, array("auth_token" => $this->token));
-        } elseif (!empty($_SESSION['phpFlickr_auth_token'])) {
-            $args = array_merge($args, array("auth_token" => $_SESSION['phpFlickr_auth_token']));
-        }
-
-        ksort($args);
-        $auth_sig = "";
-        foreach ($args as $key => $data) {
-            if ($data !== null) {
-                $auth_sig .= $key . $data;
-                $this->req->addPostData($key, $data);
-            }
-        }
-        if (!empty($this->secret)) {
-            $api_sig = md5($this->secret . $auth_sig);
-            $this->req->addPostData("api_sig", $api_sig);
-        }
-
-        $photo = realpath($photo);
-
-        $result = $this->req->addFile("photo", $photo);
-
-        if (PEAR::isError($result)) {
-            die($result->getMessage());
-        }
-
-        //Send Requests
-        if ($this->req->sendRequest()) {
-            $this->response = $this->req->getResponseBody();
-        } else {
-            die("There has been a problem sending your command to the server.");
-        }
-        $result = $this->parse_response();
-        return $result['photoid'];
-    }
-
-    function async_upload ($photo, $title = null, $description = null, $tags = null, $is_public = null, $is_friend = null, $is_family = null) {
-        $this->req->setURL($this->Upload);
-        $this->req->clearPostData();
-
-        //Process arguments, including method and login data.
-        $args = array("async" => 1, "api_key" => $this->api_key, "title" => $title, "description" => $description, "tags" => $tags, "is_public" => $is_public, "is_friend" => $is_friend, "is_family" => $is_family);
-        if (!empty($this->email)) {
-            $args = array_merge($args, array("email" => $this->email));
-        }
-        if (!empty($this->password)) {
-            $args = array_merge($args, array("password" => $this->password));
-        }
-        if (!empty($this->token)) {
-            $args = array_merge($args, array("auth_token" => $this->token));
-        } elseif (!empty($_SESSION['phpFlickr_auth_token'])) {
-            $args = array_merge($args, array("auth_token" => $_SESSION['phpFlickr_auth_token']));
-        }
-
-        ksort($args);
-        $auth_sig = "";
-        foreach ($args as $key => $data) {
-            if ($data !== null) {
-                $auth_sig .= $key . $data;
-                $this->req->addPostData($key, $data);
-            }
-        }
-        if (!empty($this->secret)) {
-            $api_sig = md5($this->secret . $auth_sig);
-            $this->req->addPostData("api_sig", $api_sig);
-        }
-
-        $photo = realpath($photo);
-
-        $result = $this->req->addFile("photo", $photo);
-
-        if (PEAR::isError($result)) {
-            die($result->getMessage());
-        }
-
-        //Send Requests
-        if ($this->req->sendRequest()) {
-            $this->response = $this->req->getResponseBody();
-        } else {
-            die("There has been a problem sending your command to the server.");
-        }
-        $result = $this->parse_response();
-        return $result['ticketid'];
-    }
-
-    function auth ($perms = "read", $remember_uri = true)
-    {
-        // Redirects to Flickr's authentication piece if there is no valid token.
-        // If remember_uri is set to false, the callback script (included) will
-        // redirect to its default page.
-
-        if (empty($_SESSION['phpFlickr_auth_token']) && empty($this->token)) {
-            if ($remember_uri) {
-                $redirect = $_SERVER['REQUEST_URI'];
-            }
-            $api_sig = md5($this->secret . "api_key" . $this->api_key . "extra" . $redirect . "perms" . $perms);
-            header("Location: http://flickr.com/services/auth/?api_key=" . $this->api_key . "&extra=" . $redirect . "&perms=" . $perms . "&api_sig=". $api_sig);
-            exit;
-        } else {
-            $tmp = $this->die_on_error;
-            $this->die_on_error = false;
-            $rsp = $this->auth_checkToken();
-            if ($this->error_code !== false) {
-                unset($_SESSION['phpFlickr_auth_token']);
-                $this->auth($perms, $remember_uri);
-            }
-            $this->die_on_error = $tmp;
-            return $rsp['perms'];
-        }
-    }
-
-    /*
-        These functions are the direct implementations of flickr calls.
-        For method documentation, including arguments, visit the address
-        included in a comment in the function.
-    */
-
-    /* Authentication methods */
-    function auth_checkToken ()
-    {
-        /* http://www.flickr.com/services/api/flickr.auth.checkToken.html */
-        $this->request('flickr.auth.checkToken');
-        $result = $this->parse_response();
-        return $result['auth'];
-    }
-
-    function auth_getFrob ()
-    {
-        /* http://www.flickr.com/services/api/flickr.auth.getFrob.html */
-        $this->request('flickr.auth.getFrob');
-        $result = $this->parse_response();
-        return $result['frob'];
-    }
-
-    function auth_getToken ($frob)
-    {
-        /* http://www.flickr.com/services/api/flickr.auth.getToken.html */
-        $this->request('flickr.auth.getToken', array('frob'=>$frob));
-        $result = $this->parse_response();
-        session_register('phpFlickr_auth_token');
-        $_SESSION['phpFlickr_auth_token'] = $result['auth']['token'];
-        return $result['auth']['token'];
-    }
-
-/* Blogs methods */
-    function blogs_getList ()
-    {
-        /* http://www.flickr.com/services/api/flickr.blogs.getList.html */
-        $this->request('flickr.blogs.getList');
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['blogs'];
-        if (!empty($result['blog']['id'])) {
-            $tmp = $result['blog'];
-            unset($result['blog']);
-            $result['blog'][] = $tmp;
-        }
-        return $result['blog'];
-    }
-
-    function blogs_postPhoto($blog_id, $photo_id, $title, $description, $blog_password = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.blogs.postPhoto.html */
-        $this->request('flickr.blogs.postPhoto', array('blog_id'=>$blog_id, 'photo_id'=>$photo_id, 'title'=>$title, 'description'=>$description, 'blog_password'=>$blog_password), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    /* Contacts Methods */
-    function contacts_getList ($filter = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.contacts.getList.html */
-        $this->request('flickr.contacts.getList', array('filter'=>$filter));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['contacts'];
-        if (!empty($result['contact']['id'])) {
-            $tmp = $result['contact'];
-            unset($result['contact']);
-            $result['contact'][] = $tmp;
-        }
-        return $result['contact'];
-    }
-
-    function contacts_getPublicList($user_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.contacts.getPublicList.html */
-        $this->request('flickr.contacts.getPublicList', array('user_id'=>$user_id));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['contacts'];
-        if (!empty($result['contact']['id'])) {
-            $tmp = $result['contact'];
-            unset($result['contact']);
-            $result['contact'][] = $tmp;
-        }
-        return $result['contact'];
-    }
-
-    /* Favorites Methods */
-    function favorites_add ($photo_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.favorites.add.html */
-        $this->request('flickr.favorites.add', array('photo_id'=>$photo_id), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function favorites_getList($user_id = NULL, $extras = NULL, $per_page = NULL, $page = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.favorites.getList.html */
-        if (is_array($extras)) { $extras = implode(",", $extras); }
-        $this->request("flickr.favorites.getList", array("user_id"=>$user_id, "extras"=>$extras, "per_page"=>$per_page, "page"=>$page));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photos'];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function favorites_getPublicList($user_id = NULL, $extras = NULL, $per_page = NULL, $page = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.favorites.getPublicList.html */
-        if (is_array($extras)) {
-            $extras = implode(",", $extras);
-        }
-        $this->request("flickr.favorites.getPublicList", array("user_id"=>$user_id, "extras"=>$extras, "per_page"=>$per_page, "page"=>$page));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photos'];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function favorites_remove($photo_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.favorites.remove.html */
-        $this->request("flickr.favorites.remove", array("photo_id"=>$photo_id), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    /* Groups Methods */
-    function groups_browse ($cat_id = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.groups.browse.html */
-        $this->request("flickr.groups.browse", array("cat_id"=>$cat_id));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['category'];
-        if (!empty($result['subcat']['id'])) {
-            $tmp = $result['subcat'];
-            unset($result['subcat']);
-            $result['subcat'][] = $tmp;
-        }
-        if (!empty($result['group']['nsid'])) {
-            $tmp = $result['group'];
-            unset($result['group']);
-            $result['group'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function groups_getInfo ($group_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.groups.getInfo.html */
-        $this->request("flickr.groups.getInfo", array("group_id"=>$group_id));
-        $this->parse_response();
-        return $this->parsed_response['rsp']["group"];
-    }
-
-    /* Groups Methods */
-    function groups_pools_add ($photo_id, $group_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.groups.pools.add.html */
-        $this->request("flickr.groups.pools.add", array("photo_id"=>$photo_id, "group_id"=>$group_id), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function groups_pools_getContext ($photo_id, $group_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.groups.pools.getContext.html */
-        $this->request("flickr.groups.pools.getContext", array("photo_id"=>$photo_id, "group_id"=>$group_id));
-        $this->parse_response();
-        return $this->parsed_response['rsp'];
-    }
-
-    function groups_pools_getGroups ()
-    {
-        /* http://www.flickr.com/services/api/flickr.groups.pools.getGroups.html */
-        $this->request("flickr.groups.pools.getGroups");
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['groups']['group'];
-        if (!empty($result['id'])) {
-            $tmp = $result;
-            unset($result);
-            $result[] = $tmp;
-        }
-        return $result;
-    }
-
-    function groups_pools_getPhotos ($group_id, $tags = NULL, $user_id = NULL, $extras = NULL, $per_page = NULL, $page = NULL)
-    {
-		/* http://www.flickr.com/services/api/flickr.groups.pools.getPhotos.html */
-        if (is_array($extras)) {
-            $extras = implode(",", $extras);
-        }
-        $this->request("flickr.groups.pools.getPhotos", array("group_id"=>$group_id, "tags"=>$tags, "user_id"=>$user_id, "extras"=>$extras, "per_page"=>$per_page, "page"=>$page));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photos'];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function groups_pools_remove ($photo_id, $group_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.groups.pools.remove.html */
-        $this->request("flickr.groups.pools.remove", array("photo_id"=>$photo_id, "group_id"=>$group_id), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    /* Interestingness methods */
-	function interestingness_getList($date = NULL, $extras = NULL, $per_page = NULL, $page = NULL)
-	{
-        /* http://www.flickr.com/services/api/flickr.interestingness.getList.html */
-        if (is_array($extras)) {
-            $extras = implode(",", $extras);
-        }
-
-        $this->request("flickr.interestingness.getList", array("date"=>$date, "extras"=>$extras, "per_page"=>$per_page, "page"=>$page));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photos'];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result;
-    }
-
-    /* People methods */
-    function people_findByEmail ($find_email)
-    {
-        /* http://www.flickr.com/services/api/flickr.people.findByEmail.html */
-        $this->request("flickr.people.findByEmail", array("find_email"=>$find_email));
-        $this->parse_response();
-        return $this->parsed_response['rsp']["user"]["nsid"];
-    }
-
-    function people_findByUsername ($username)
-    {
-        /* http://www.flickr.com/services/api/flickr.people.findByUsername.html */
-        $this->request("flickr.people.findByUsername", array("username"=>$username));
-        $this->parse_response();
-        return $this->parsed_response['rsp']["user"]["nsid"];
-    }
-
-    function people_getInfo($user_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.people.getInfo.html */
-        $this->request("flickr.people.getInfo", array("user_id"=>$user_id));
-        $this->parse_response();
-        return $this->parsed_response['rsp']["person"];
-    }
-
-    function people_getPublicGroups($user_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.people.getPublicGroups.html */
-        $this->request("flickr.people.getPublicGroups", array("user_id"=>$user_id));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['groups'];
-        if (!empty($result['group']['nsid'])) {
-            $tmp = $result['group'];
-            unset($result['group']);
-            $result['group'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function people_getPublicPhotos($user_id, $extras = NULL, $per_page = NULL, $page = NULL) {
-        /* http://www.flickr.com/services/api/flickr.people.getPublicPhotos.html */
-        if (is_array($extras)) {
-            $extras = implode(",", $extras);
-        }
-
-        $this->request("flickr.people.getPublicPhotos", array("user_id"=>$user_id, "extras"=>$extras, "per_page"=>$per_page, "page"=>$page));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photos'];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function people_getUploadStatus($user_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.people.getUploadStatus.html */
-        /* Requires Authentication */
-        $this->request("flickr.people.getUploadStatus");
-        $this->parse_response();
-        return $this->parsed_response['rsp']['user'];
-    }
-
-
-    /* Photos Methods */
-    function photos_addTags ($photo_id, $tags)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.addTags.html */
-        $this->request("flickr.photos.addTags", array("photo_id"=>$photo_id, "tags"=>$tags), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photos_delete($photo_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.delete.html */
-        $this->request("flickr.photos.delete", array("photo_id"=>$photo_id), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photos_getAllContexts ($photo_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getAllContexts.html */
-        $this->request("flickr.photos.getAllContexts", array("photo_id"=>$photo_id));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp'];
-        if (!empty($result['set']['id'])) {
-            $tmp = $result['set'];
-            unset($result['set']);
-            $result['set'][] = $tmp;
-        }
-        if (!empty($result['pool']['id'])) {
-            $tmp = $result['pool'];
-            unset($result['pool']);
-            $result['pool'][] = $tmp;
-        }
-        return $result;    }
-
-    function photos_getContactsPhotos ($count = NULL, $just_friends = NULL, $single_photo = NULL, $include_self = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getContactsPhotos.html */
-        $this->request("flickr.photos.getContactsPhotos", array("count"=>$count, "just_friends"=>$just_friends, "single_photo"=>$single_photo, "include_self"=>$include_self));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photos'];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result['photo'];
-    }
-
-    function photos_getContactsPublicPhotos ($user_id, $count = NULL, $just_friends = NULL, $single_photo = NULL, $include_self = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getContactsPublicPhotos.html */
-        $this->request("flickr.photos.getContactsPublicPhotos", array("user_id"=>$user_id, "count"=>$count, "just_friends"=>$just_friends, "single_photo"=>$single_photo, "include_self"=>$include_self));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photos'];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result['photo'];
-    }
-
-    function photos_getContext ($photo_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getContext.html */
-        $this->request("flickr.photos.getContext", array("photo_id"=>$photo_id));
-        $this->parse_response();
-        return $this->parsed_response['rsp'];
-    }
-
-    function photos_getCounts ($dates = NULL, $taken_dates = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getCounts.html */
-        $this->request("flickr.photos.getCounts", array("dates"=>$dates, "taken_dates"=>$taken_dates));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photocounts'];
-        if (!empty($result['photocount']['count'])) {
-            $tmp = $result['photocount'];
-            unset($result['photocount']);
-            $result['photocount'][] = $tmp;
-        }
-        return $result['photocount'];
-    }
-
-    function photos_getExif ($photo_id, $secret = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getExif.html */
-        $this->request("flickr.photos.getExif", array("photo_id"=>$photo_id, "secret"=>$secret));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photo'];
-        if (!empty($result['exif']['tagspace'])) {
-            $tmp = $result['exif'];
-            unset($result['exif']);
-            $result['exif'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function photos_getInfo($photo_id, $secret = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getInfo.html */
-        $this->request("flickr.photos.getInfo", array("photo_id"=>$photo_id, "secret"=>$secret));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photo'];
-        if (!empty($result['urls']['url']['type'])) {
-            $tmp = $result['urls']['url'];
-            unset($result['urls']['url']);
-            $result['urls']['url'][] = $tmp;
-        }
-        if (!empty($result['tags']['tag']['id'])) {
-            $tmp = $result['tags']['tag'];
-            unset($result['tags']['tag']);
-            $result['tags']['tag'][] = $tmp;
-        }
-        if (!empty($result['notes']['note']['id'])) {
-            $tmp = $result['notes']['note'];
-            unset($result['notes']['note']);
-            $result['notes']['note'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function photos_getNotInSet($extras = NULL, $per_page = NULL, $page = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getNotInSet.html */
-        if (is_array($extras)) {
-            $extras = implode(",", $extras);
-        }
-        $this->request("flickr.photos.getNotInSet", array("extras"=>$extras, "per_page"=>$per_page, "page"=>$page));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']["photos"];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function photos_getPerms($photo_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getPerms.html */
-        $this->request("flickr.photos.getPerms", array("photo_id"=>$photo_id));
-        $this->parse_response();
-        return $this->parsed_response['rsp']["perms"];
-    }
-
-    function photos_getRecent($extras = NULL, $per_page = NULL, $page = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getRecent.html */
-        if (is_array($extras)) {
-            $extras = implode(",", $extras);
-        }
-
-        $this->request("flickr.photos.getRecent", array("extras"=>$extras, "per_page"=>$per_page, "page"=>$page));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photos'];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function photos_getSizes($photo_id, $secret = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getSizes.html */
-        $this->request("flickr.photos.getSizes", array("photo_id"=>$photo_id));
-        $this->parse_response();
-        foreach($this->parsed_response['rsp']["sizes"]['size'] as $size) {
-            $result[$size["label"]] = $size;
-        }
-        return $result;
-    }
-
-    function photos_getUntagged($extras = NULL, $per_page = NULL, $page = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.getUntagged.html */
-        if (is_array($extras)) {
-            $extras = implode(",", $extras);
-        }
-        $this->request("flickr.photos.getUntagged", array("extras"=>$extras, "per_page"=>$per_page, "page"=>$page));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photos'];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function photos_removeTag($tag_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.removeTag.html */
-        $this->request("flickr.photos.removeTag", array("tag_id"=>$tag_id), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photos_search($args)
-    {
-        /* This function strays from the method of arguments that I've
-         * used in the other functions for the fact that there are just
-         * so many arguments to this API method. What you'll need to do
-         * is pass an associative array to the function containing the
-         * arguments you want to pass to the API.  For example:
-         *   $photos = $f->photos_search(array("tags"=>"brown,cow", "tag_mode"=>"any"));
-         * This will return photos tagged with either "brown" or "cow"
-         * or both. See the API documentation (link below) for a full
-         * list of arguments.
-         */
-
-        /* http://www.flickr.com/services/api/flickr.photos.search.html */
-        $this->request("flickr.photos.search", $args);
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photos'];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function photos_setDates($photo_id, $date_posted = NULL, $date_taken = NULL, $date_taken_granularity = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.setDates.html */
-        $this->request("flickr.photos.setDates", array("photo_id"=>$photo_id, "date_posted"=>$date_posted, "date_taken"=>$date_taken, "date_taken_granularity"=>$date_taken_granularity), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photos_setMeta($photo_id, $title, $description)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.setMeta.html */
-        $this->request("flickr.photos.setMeta", array("photo_id"=>$photo_id, "title"=>$title, "description"=>$description), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photos_setPerms($photo_id, $is_public, $is_friend, $is_family, $perm_comment, $perm_addmeta)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.setPerms.html */
-        $this->request("flickr.photos.setPerms", array("photo_id"=>$photo_id, "is_public"=>$is_public, "is_friend"=>$is_friend, "is_family"=>$is_family, "perm_comment"=>$perm_comment, "perm_addmeta"=>$perm_addmeta), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photos_setTags($photo_id, $tags)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.setTags.html */
-        $this->request("flickr.photos.setTags", array("photo_id"=>$photo_id, "tags"=>$tags), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    /* Photos - Notes Methods */
-    function photos_licenses_getInfo()
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.licenses.getInfo.html */
-        $this->request("flickr.photos.licenses.getInfo");
-        $this->parse_response();
-        return $this->parsed_response['rsp']['licenses'];
-    }
-
-    function photos_licenses_setLicense($photo_id, $license_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.licenses.setLicense.html */
-        /* Requires Authentication */
-        $this->request("flickr.photos.licenses.setLicense", array("photo_id"=>$photo_ID, "license_id"=>$license_id), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    /* Photos - Notes Methods */
-    function photos_notes_add($photo_id, $note_x, $note_y, $note_w, $note_h, $note_text)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.notes.add.html */
-        $this->request("flickr.photos.notes.add", array("photo_id" => $photo_id, "note_x" => $note_x, "note_y" => $note_y, "note_w" => $note_w, "note_h" => $note_h, "note_text" => $note_text), TRUE);
-        $this->parse_response();
-        return $this->parsed_response['rsp']['note']['id'];
-    }
-
-    function photos_notes_delete($note_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.notes.delete.html */
-        $this->request("flickr.photos.notes.delete", array("note_id" => $note_id), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photos_notes_edit($note_id, $note_x, $note_y, $note_w, $note_h, $note_text)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.notes.edit.html */
-        $this->request("flickr.photos.notes.edit", array("note_id" => $note_id, "note_x" => $note_x, "note_y" => $note_y, "note_w" => $note_w, "note_h" => $note_h, "note_text" => $note_text), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    /* Photos - Transform Methods */
-    function photos_transform_rotate($photo_id, $degrees)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.transform.rotate.html */
-        $this->request("flickr.photos.transform.rotate", array("photo_id" => $photo_id, "degrees" => $degrees), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    /* Photos - Upload Methods */
-    function photos_upload_checkTickets($tickets)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.upload.checkTickets.html */
-        if (is_array($tickets)) {
-            $tickets = implode(",", $tickets);
-        }
-        $this->request("flickr.photos.upload.checkTickets", array("tickets" => $tickets), TRUE);
-        $result = $this->parse_response();
-        if (!empty($result['uploader']['ticket']['id'])) {
-            $tmp = $result['uploader']['ticket'];
-            unset($result['uploader']['ticket']);
-            $result['uploader']['ticket'][] = $tmp;
-        }
-        return $result['uploader']['ticket'];
-    }
-
-    /* Photosets Methods */
-    function photosets_addPhoto($photoset_id, $photo_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photosets.addPhoto.html */
-        $this->request("flickr.photosets.addPhoto", array("photoset_id" => $photoset_id, "photo_id" => $photo_id), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photosets_create($title, $description, $primary_photo_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photosets.create.html */
-        $this->request("flickr.photosets.create", array("title" => $title, "primary_photo_id" => $primary_photo_id, "description" => $description), TRUE);
-        $this->parse_response();
-        return $this->parsed_response['rsp']['photoset'];
-    }
-
-    function photosets_delete($photoset_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photosets.delete.html */
-        $this->request("flickr.photosets.delete", array("photoset_id" => $photoset_id), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photosets_editMeta($photoset_id, $title, $description = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photosets.editMeta.html */
-        $this->request("flickr.photosets.editMeta", array("photoset_id" => $photoset_id, "title" => $title, "description" => $description), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photosets_editPhotos($photoset_id, $primary_photo_id, $photo_ids)
-    {
-        /* http://www.flickr.com/services/api/flickr.photosets.editPhotos.html */
-        $this->request("flickr.photosets.editPhotos", array("photoset_id" => $photoset_id, "primary_photo_id" => $primary_photo_id, "photo_ids" => $photo_ids), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photosets_getContext($photo_id, $photoset_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photosets.getContext.html */
-        $this->request("flickr.photosets.getContext", array("photo_id" => $photo_id, "photoset_id" => $photoset_id));
-        $this->parse_response();
-        return $this->parsed_response['rsp'];
-    }
-
-    function photosets_getInfo($photoset_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photosets.getInfo.html */
-        $this->request("flickr.photosets.getInfo", array("photoset_id" => $photoset_id));
-        $this->parse_response();
-        return $this->parsed_response['rsp']['photoset'];
-    }
-
-    function photosets_getList($user_id = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photosets.getList.html */
-        $this->request("flickr.photosets.getList", array("user_id" => $user_id));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photosets'];
-        if (!empty($result['photoset']['id'])) {
-            $tmp = $result['photoset'];
-            unset($result['photoset']);
-            $result['photoset'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function photosets_getPhotos($photoset_id, $extras = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.photosets.getPhotos.html */
-        $this->request("flickr.photosets.getPhotos", array("photoset_id" => $photoset_id, "extras" => $extras));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photoset'];
-        if (!empty($result['photo']['id'])) {
-            $tmp = $result['photo'];
-            unset($result['photo']);
-            $result['photo'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function photosets_orderSets($photoset_ids)
-    {
-        /* http://www.flickr.com/services/api/flickr.photosets.orderSets.html */
-        if (is_array($photoset_ids)) {
-            $photoset_ids = implode(",", $photoset_ids);
-        }
-        $this->request("flickr.photosets.orderSets", array("photoset_ids" => $photoset_ids), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    function photosets_removePhoto($photoset_id, $photo_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.photosets.removePhoto.html */
-        $this->request("flickr.photosets.removePhoto", array("photoset_id" => $photoset_id, "photo_id" => $photo_id), TRUE);
-        $this->parse_response();
-        return true;
-    }
-
-    /* Reflection Methods */
-    function reflection_getMethodInfo($method_name)
-    {
-        /* http://www.flickr.com/services/api/flickr.reflection.getMethodInfo.html */
-        $this->request("flickr.reflection.getMethodInfo", array("method_name" => $method_name));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['method'];
-        if (!empty($result['arguments']['argument']['name'])) {
-            $tmp = $result['arguments']['argument'];
-            unset($result['arguments']['argument']);
-            $result['arguments']['argument'][] = $tmp;
-        }
-        if (!empty($result['errors']['error']['code'])) {
-            $tmp = $result['errors']['error'];
-            unset($result['errors']['error']);
-            $result['errors']['error'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function reflection_getMethods()
-    {
-        /* http://www.flickr.com/services/api/flickr.reflection.getMethods.html */
-        $this->request("flickr.reflection.getMethods");
-        $this->parse_response();
-        return $this->parsed_response['rsp']['methods'];
-    }
-
-    /* Tags Methods */
-    function tags_getListPhoto($photo_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.tags.getListPhoto.html */
-        $this->request("flickr.tags.getListPhoto", array("photo_id" => $photo_id));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['photo'];
-        if (!empty($result['tags']['tag']['id'])) {
-            $tmp = $result['tags']['tag'];
-            unset($result['tags']['tag']);
-            $result['tags']['tag'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function tags_getListUser($user_id = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.tags.getListUser.html */
-        $this->request("flickr.tags.getListUser", array("user_id" => $user_id));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['who'];
-        if (!is_array($result['tags']['tag'])) {
-            $tmp = $result['tags']['tag'];
-            unset($result['tags']['tag']);
-            $result['tags']['tag'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function tags_getListUserPopular($user_id = NULL, $count = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.tags.getListUserPopular.html */
-        $this->request("flickr.tags.getListUserPopular", array("user_id" => $user_id, "count" => $count));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['who'];
-        if (!empty($result['tags']['tag']['count'])) {
-            $tmp = $result['tags']['tag'];
-            unset($result['tags']['tag']);
-            $result['tags']['tag'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function tags_getRelated($tag)
-    {
-        /* http://www.flickr.com/services/api/flickr.tags.getRelated.html */
-        $this->request("flickr.tags.getRelated", array("tag" => $tag));
-        $this->parse_response();
-        $result = $this->parsed_response['rsp']['tags'];
-        if (!is_array($result['tag'])) {
-            $tmp = $result['tag'];
-            unset($result['tag']);
-            $result['tag'][] = $tmp;
-        }
-        return $result;
-    }
-
-    function test_echo($args = array())
-    {
-        /* http://www.flickr.com/services/api/flickr.test.echo.html */
-        $this->request("flickr.test.echo", $args);
-        $this->parse_response();
-        return $this->parsed_response['rsp'];
-    }
-
-    function test_login()
-    {
-        /* http://www.flickr.com/services/api/flickr.test.login.html */
-        $this->request("flickr.test.login");
-        $this->parse_response();
-        return $this->parsed_response['rsp']['user'];
-    }
-
-    function urls_getGroup($group_id)
-    {
-        /* http://www.flickr.com/services/api/flickr.urls.getGroup.html */
-        $this->request("flickr.urls.getGroup", array("group_id"=>$group_id));
-        $this->parse_response();
-        return $this->parsed_response['rsp']["group"]["url"];
-    }
-
-    function urls_getUserPhotos($user_id = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.urls.getUserPhotos.html */
-        $this->request("flickr.urls.getUserPhotos", array("user_id"=>$user_id));
-        $this->parse_response();
-        return $this->parsed_response['rsp']["user"]["url"];
-    }
-
-    function urls_getUserProfile($user_id = NULL)
-    {
-        /* http://www.flickr.com/services/api/flickr.urls.getUserProfile.html */
-        $this->request("flickr.urls.getUserProfile", array("user_id"=>$user_id));
-        $this->parse_response();
-        return $this->parsed_response['rsp']["user"]["url"];
-    }
-
-    function urls_lookupGroup($url)
-    {
-        /* http://www.flickr.com/services/api/flickr.urls.lookupGroup.html */
-        $this->request("flickr.urls.lookupGroup", array("url"=>$url));
-        $this->parse_response();
-        return $this->parsed_response['rsp']["group"];
-    }
-
-    function urls_lookupUser($url)
-    {
-        /* http://www.flickr.com/services/api/flickr.photos.notes.edit.html */
-        $this->request("flickr.urls.lookupUser", array("url"=>$url));
-        $this->parse_response();
-        return $this->parsed_response['rsp']["user"];
-    }
+		}
+
+		function cache ($request, $response)
+		{
+			//Caches the unparsed response of a request.
+			unset($request['api_sig']);
+			foreach ( $request as $key => $value ) {
+				if ( empty($value) ) unset($request[$key]);
+				else $request[$key] = (string) $request[$key];
+			}
+			$reqhash = md5(serialize($request));
+			if ($this->cache == 'db') {
+				//$this->cache_db->query("DELETE FROM $this->cache_table WHERE request = '$reqhash'");
+				$response = urlencode($response);
+				$sql = 'INSERT INTO '.$this->cache_table.' (request, response, expiration) 
+						VALUES (\''.$reqhash.'\', \''.$response.'\', TIMESTAMPADD(SECOND,'.$this->cache_expire.',CURRENT_TIMESTAMP))
+						ON DUPLICATE KEY UPDATE response=\''.$response.'\', 
+						expiration=TIMESTAMPADD(SECOND,'.$this->cache_expire.',CURRENT_TIMESTAMP) ';
+
+				$result = mysqli_query($this->cache_db, $sql);
+				if(!$result) {
+					echo mysqli_error($this->cache_db);
+				}
+					
+				return $result;
+			} elseif ($this->cache == "fs") {
+				$file = $this->cache_dir . "/" . $reqhash . ".cache";
+				$fstream = fopen($file, "w");
+				$result = fwrite($fstream,$response);
+				fclose($fstream);
+				return $result;
+			} elseif ( $this->cache == "custom" ) {
+				return call_user_func_array($this->custom_cache_set, array($reqhash, $response, $this->cache_expire));
+			}
+			return false;
+		}
+
+		function setCustomPost ( $function ) {
+			$this->custom_post = $function;
+		}
+
+		function post ($data, $type = null) {
+			if ( is_null($type) ) {
+				$url = $this->rest_endpoint;
+			}
+
+			if ( !is_null($this->custom_post) ) {
+				return call_user_func($this->custom_post, $url, $data);
+			}
+
+			if ( !preg_match("|https://(.*?)(/.*)|", $url, $matches) ) {
+				die('There was some problem figuring out your endpoint');
+			}
+
+			if ( function_exists('curl_init') ) {
+				// Has curl. Use it!
+				$curl = curl_init($this->rest_endpoint);
+				curl_setopt($curl, CURLOPT_POST, true);
+				curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
+				curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+				$response = curl_exec($curl);
+				curl_close($curl);
+			} else {
+				// Use sockets.
+				foreach ( $data as $key => $value ) {
+					$data[$key] = $key . '=' . urlencode($value);
+				}
+				$data = implode('&', $data);
+
+				$fp = @pfsockopen('ssl://'.$matches[1], 443);
+				if (!$fp) {
+					die('Could not connect to the web service');
+				}
+				fputs ($fp,'POST ' . $matches[2] . " HTTP/1.1\n");
+				fputs ($fp,'Host: ' . $matches[1] . "\n");
+				fputs ($fp,"Content-type: application/x-www-form-urlencoded\n");
+				fputs ($fp,"Content-length: ".strlen($data)."\n");
+				fputs ($fp,"Connection: close\r\n\r\n");
+				fputs ($fp,$data . "\n\n");
+				$response = "";
+				while(!feof($fp)) {
+					$response .= fgets($fp, 1024);
+				}
+				fclose ($fp);
+				$chunked = false;
+				$http_status = trim(substr($response, 0, strpos($response, "\n")));
+				if ( $http_status != 'HTTP/1.1 200 OK' ) {
+					die('The web service endpoint returned a "' . $http_status . '" response');
+				}
+				if ( strpos($response, 'Transfer-Encoding: chunked') !== false ) {
+					$temp = trim(strstr($response, "\r\n\r\n"));
+					$response = '';
+					$length = trim(substr($temp, 0, strpos($temp, "\r")));
+					while ( trim($temp) != "0" && ($length = trim(substr($temp, 0, strpos($temp, "\r")))) != "0" ) {
+						$response .= trim(substr($temp, strlen($length)+2, hexdec($length)));
+						$temp = trim(substr($temp, strlen($length) + 2 + hexdec($length)));
+					}
+				} elseif ( strpos($response, 'HTTP/1.1 200 OK') !== false ) {
+					$response = trim(strstr($response, "\r\n\r\n"));
+				}
+			}
+			return $response;
+		}
+
+		function request ($command, $args = array(), $nocache = false)
+		{
+			//Sends a request to Flickr's REST endpoint via POST.
+			if (substr($command,0,7) != "flickr.") {
+				$command = "flickr." . $command;
+			}
+
+			//Process arguments, including method and login data.
+			$args = array_merge(array("method" => $command, "format" => "json", "nojsoncallback" => "1", "api_key" => $this->api_key), $args);
+			if (!empty($this->token)) {
+				$args = array_merge($args, array("auth_token" => $this->token));
+			} elseif (!empty($_SESSION['phpFlickr_auth_token'])) {
+				$args = array_merge($args, array("auth_token" => $_SESSION['phpFlickr_auth_token']));
+			}
+			ksort($args);
+			$auth_sig = "";
+			$this->last_request = $args;
+			$this->response = $this->getCached($args);
+			if (!($this->response) || $nocache) {
+				foreach ($args as $key => $data) {
+					if ( is_null($data) ) {
+						unset($args[$key]);
+						continue;
+					}
+					$auth_sig .= $key . $data;
+				}
+				if (!empty($this->secret)) {
+					$api_sig = md5($this->secret . $auth_sig);
+					$args['api_sig'] = $api_sig;
+				}
+				$this->response = $this->post($args);
+				$this->cache($args, $this->response);
+			}
+
+
+			/*
+			 * Uncomment this line (and comment out the next one) if you're doing large queries
+			 * and you're concerned about time.  This will, however, change the structure of
+			 * the result, so be sure that you look at the results.
+			 */
+			$this->parsed_response = json_decode($this->response, TRUE);
+/* 			$this->parsed_response = $this->clean_text_nodes(json_decode($this->response, TRUE)); */
+			if ($this->parsed_response['stat'] == 'fail') {
+				if ($this->die_on_error) die("The Flickr API returned the following error: #{$this->parsed_response['code']} - {$this->parsed_response['message']}");
+				else {
+					$this->error_code = $this->parsed_response['code'];
+					$this->error_msg = $this->parsed_response['message'];
+					$this->parsed_response = false;
+				}
+			} else {
+				$this->error_code = false;
+				$this->error_msg = false;
+			}
+			return $this->response;
+		}
+
+		function clean_text_nodes ($arr) {
+			if (!is_array($arr)) {
+				return $arr;
+			} elseif (count($arr) == 0) {
+				return $arr;
+			} elseif (count($arr) == 1 && array_key_exists('_content', $arr)) {
+				return $arr['_content'];
+			} else {
+				foreach ($arr as $key => $element) {
+					$arr[$key] = $this->clean_text_nodes($element);
+				}
+				return($arr);
+			}
+		}
+
+		function setToken ($token) {
+			// Sets an authentication token to use instead of the session variable
+			$this->token = $token;
+		}
+
+		function setProxy ($server, $port) {
+			// Sets the proxy for all phpFlickr calls.
+			$this->req->setProxy($server, $port);
+		}
+
+		function getErrorCode () {
+			// Returns the error code of the last call.  If the last call did not
+			// return an error. This will return a false boolean.
+			return $this->error_code;
+		}
+
+		function getErrorMsg () {
+			// Returns the error message of the last call.  If the last call did not
+			// return an error. This will return a false boolean.
+			return $this->error_msg;
+		}
+
+		/* These functions are front ends for the flickr calls */
+
+		function buildPhotoURL ($photo, $size = "Medium") {
+			//receives an array (can use the individual photo data returned
+			//from an API call) and returns a URL (doesn't mean that the
+			//file size exists)
+			$sizes = array(
+				"square" => "_s",
+				"square_75" => "_s",
+				"square_150" => "_q",
+				"thumbnail" => "_t",
+				"small" => "_m",
+				"small_240" => "_m",
+				"small_320" => "_n",
+				"medium" => "",
+				"medium_500" => "",
+				"medium_640" => "_z",
+				"medium_800" => "_c",
+				"large" => "_b",
+				"large_1024" => "_b",
+				"large_1600" => "_h",
+				"large_2048" => "_k",
+				"original" => "_o",
+			);
+
+			$size = strtolower($size);
+			if (!array_key_exists($size, $sizes)) {
+				$size = "medium";
+			}
+
+			if ($size == "original") {
+				$url = "https://farm" . $photo['farm'] . ".static.flickr.com/" . $photo['server'] . "/" . $photo['id'] . "_" . $photo['originalsecret'] . "_o" . "." . $photo['originalformat'];
+			} else {
+				$url = "https://farm" . $photo['farm'] . ".static.flickr.com/" . $photo['server'] . "/" . $photo['id'] . "_" . $photo['secret'] . $sizes[$size] . ".jpg";
+			}
+			return $url;
+		}
+
+		function sync_upload ($photo, $title = null, $description = null, $tags = null, $is_public = null, $is_friend = null, $is_family = null) {
+			if ( function_exists('curl_init') ) {
+				// Has curl. Use it!
+
+				//Process arguments, including method and login data.
+				$args = array("api_key" => $this->api_key, "title" => $title, "description" => $description, "tags" => $tags, "is_public" => $is_public, "is_friend" => $is_friend, "is_family" => $is_family);
+				if (!empty($this->token)) {
+					$args = array_merge($args, array("auth_token" => $this->token));
+				} elseif (!empty($_SESSION['phpFlickr_auth_token'])) {
+					$args = array_merge($args, array("auth_token" => $_SESSION['phpFlickr_auth_token']));
+				}
+
+				ksort($args);
+				$auth_sig = "";
+				foreach ($args as $key => $data) {
+					if ( is_null($data) ) {
+						unset($args[$key]);
+					} else {
+						$auth_sig .= $key . $data;
+					}
+				}
+				if (!empty($this->secret)) {
+					$api_sig = md5($this->secret . $auth_sig);
+					$args["api_sig"] = $api_sig;
+				}
+
+				$photo = realpath($photo);
+				$args['photo'] = '@' . $photo;
+
+
+				$curl = curl_init($this->upload_endpoint);
+				curl_setopt($curl, CURLOPT_POST, true);
+				curl_setopt($curl, CURLOPT_POSTFIELDS, $args);
+				curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+				$response = curl_exec($curl);
+				$this->response = $response;
+				curl_close($curl);
+
+				$rsp = explode("\n", $response);
+				foreach ($rsp as $line) {
+					if (preg_match('|<err code="([0-9]+)" msg="(.*)"|', $line, $match)) {
+						if ($this->die_on_error)
+							die("The Flickr API returned the following error: #{$match[1]} - {$match[2]}");
+						else {
+							$this->error_code = $match[1];
+							$this->error_msg = $match[2];
+							$this->parsed_response = false;
+							return false;
+						}
+					} elseif (preg_match("|<photoid>(.*)</photoid>|", $line, $match)) {
+						$this->error_code = false;
+						$this->error_msg = false;
+						return $match[1];
+					}
+				}
+
+			} else {
+				die("Sorry, your server must support CURL in order to upload files");
+			}
+
+		}
+
+		function async_upload ($photo, $title = null, $description = null, $tags = null, $is_public = null, $is_friend = null, $is_family = null) {
+			if ( function_exists('curl_init') ) {
+				// Has curl. Use it!
+
+				//Process arguments, including method and login data.
+				$args = array("async" => 1, "api_key" => $this->api_key, "title" => $title, "description" => $description, "tags" => $tags, "is_public" => $is_public, "is_friend" => $is_friend, "is_family" => $is_family);
+				if (!empty($this->token)) {
+					$args = array_merge($args, array("auth_token" => $this->token));
+				} elseif (!empty($_SESSION['phpFlickr_auth_token'])) {
+					$args = array_merge($args, array("auth_token" => $_SESSION['phpFlickr_auth_token']));
+				}
+
+				ksort($args);
+				$auth_sig = "";
+				foreach ($args as $key => $data) {
+					if ( is_null($data) ) {
+						unset($args[$key]);
+					} else {
+						$auth_sig .= $key . $data;
+					}
+				}
+				if (!empty($this->secret)) {
+					$api_sig = md5($this->secret . $auth_sig);
+					$args["api_sig"] = $api_sig;
+				}
+
+				$photo = realpath($photo);
+				$args['photo'] = '@' . $photo;
+
+
+				$curl = curl_init($this->upload_endpoint);
+				curl_setopt($curl, CURLOPT_POST, true);
+				curl_setopt($curl, CURLOPT_POSTFIELDS, $args);
+				curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+				$response = curl_exec($curl);
+				$this->response = $response;
+				curl_close($curl);
+
+				$rsp = explode("\n", $response);
+				foreach ($rsp as $line) {
+					if (preg_match('/<err code="([0-9]+)" msg="(.*)"/', $line, $match)) {
+						if ($this->die_on_error)
+							die("The Flickr API returned the following error: #{$match[1]} - {$match[2]}");
+						else {
+							$this->error_code = $match[1];
+							$this->error_msg = $match[2];
+							$this->parsed_response = false;
+							return false;
+						}
+					} elseif (preg_match("/<ticketid>(.*)</", $line, $match)) {
+						$this->error_code = false;
+						$this->error_msg = false;
+						return $match[1];
+					}
+				}
+			} else {
+				die("Sorry, your server must support CURL in order to upload files");
+			}
+		}
+
+		// Interface for new replace API method.
+		function replace ($photo, $photo_id, $async = null) {
+			if ( function_exists('curl_init') ) {
+				// Has curl. Use it!
+
+				//Process arguments, including method and login data.
+				$args = array("api_key" => $this->api_key, "photo_id" => $photo_id, "async" => $async);
+				if (!empty($this->token)) {
+					$args = array_merge($args, array("auth_token" => $this->token));
+				} elseif (!empty($_SESSION['phpFlickr_auth_token'])) {
+					$args = array_merge($args, array("auth_token" => $_SESSION['phpFlickr_auth_token']));
+				}
+
+				ksort($args);
+				$auth_sig = "";
+				foreach ($args as $key => $data) {
+					if ( is_null($data) ) {
+						unset($args[$key]);
+					} else {
+						$auth_sig .= $key . $data;
+					}
+				}
+				if (!empty($this->secret)) {
+					$api_sig = md5($this->secret . $auth_sig);
+					$args["api_sig"] = $api_sig;
+				}
+
+				$photo = realpath($photo);
+				$args['photo'] = '@' . $photo;
+
+
+				$curl = curl_init($this->replace_endpoint);
+				curl_setopt($curl, CURLOPT_POST, true);
+				curl_setopt($curl, CURLOPT_POSTFIELDS, $args);
+				curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+				$response = curl_exec($curl);
+				$this->response = $response;
+				curl_close($curl);
+
+				if ($async == 1)
+					$find = 'ticketid';
+				 else
+					$find = 'photoid';
+
+				$rsp = explode("\n", $response);
+				foreach ($rsp as $line) {
+					if (preg_match('|<err code="([0-9]+)" msg="(.*)"|', $line, $match)) {
+						if ($this->die_on_error)
+							die("The Flickr API returned the following error: #{$match[1]} - {$match[2]}");
+						else {
+							$this->error_code = $match[1];
+							$this->error_msg = $match[2];
+							$this->parsed_response = false;
+							return false;
+						}
+					} elseif (preg_match("|<" . $find . ">(.*)</|", $line, $match)) {
+						$this->error_code = false;
+						$this->error_msg = false;
+						return $match[1];
+					}
+				}
+			} else {
+				die("Sorry, your server must support CURL in order to upload files");
+			}
+		}
+
+		function auth ($perms = "read", $remember_uri = true) {
+			// Redirects to Flickr's authentication piece if there is no valid token.
+			// If remember_uri is set to false, the callback script (included) will
+			// redirect to its default page.
+
+			if (empty($_SESSION['phpFlickr_auth_token']) && empty($this->token)) {
+				if ( $remember_uri === true ) {
+					$_SESSION['phpFlickr_auth_redirect'] = $_SERVER['REQUEST_URI'];
+				} elseif ( $remember_uri !== false ) {
+					$_SESSION['phpFlickr_auth_redirect'] = $remember_uri;
+				}
+				$api_sig = md5($this->secret . "api_key" . $this->api_key . "perms" . $perms);
+
+				if ($this->service == "23") {
+					header("Location: http://www.23hq.com/services/auth/?api_key=" . $this->api_key . "&perms=" . $perms . "&api_sig=". $api_sig);
+				} else {
+					header("Location: https://www.flickr.com/services/auth/?api_key=" . $this->api_key . "&perms=" . $perms . "&api_sig=". $api_sig);
+				}
+				exit;
+			} else {
+				$tmp = $this->die_on_error;
+				$this->die_on_error = false;
+				$rsp = $this->auth_checkToken();
+				if ($this->error_code !== false) {
+					unset($_SESSION['phpFlickr_auth_token']);
+					$this->auth($perms, $remember_uri);
+				}
+				$this->die_on_error = $tmp;
+				return $rsp['perms'];
+			}
+		}
+
+		function auth_url($frob, $perms = 'read') {
+			$sig = md5(sprintf('%sapi_key%sfrob%sperms%s', $this->secret, $this->api_key, $frob, $perms));
+			return sprintf('https://flickr.com/services/auth/?api_key=%s&perms=%s&frob=%s&api_sig=%s', $this->api_key, $perms, $frob, $sig);
+		}
+
+		/*******************************
+
+		To use the phpFlickr::call method, pass a string containing the API method you want
+		to use and an associative array of arguments.  For example:
+			$result = $f->call("flickr.photos.comments.getList", array("photo_id"=>'34952612'));
+		This method will allow you to make calls to arbitrary methods that haven't been
+		implemented in phpFlickr yet.
+
+		*******************************/
+
+		function call ($method, $arguments) {
+			foreach ( $arguments as $key => $value ) {
+				if ( is_null($value) ) unset($arguments[$key]);
+			}
+			$this->request($method, $arguments);
+			return $this->parsed_response ? $this->parsed_response : false;
+		}
+
+		/*
+			These functions are the direct implementations of flickr calls.
+			For method documentation, including arguments, visit the address
+			included in a comment in the function.
+		*/
+
+		/* Activity methods */
+		function activity_userComments ($per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.activity.userComments.html */
+			$this->request('flickr.activity.userComments', array("per_page" => $per_page, "page" => $page));
+			return $this->parsed_response ? $this->parsed_response['items']['item'] : false;
+		}
+
+		function activity_userPhotos ($timeframe = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.activity.userPhotos.html */
+			$this->request('flickr.activity.userPhotos', array("timeframe" => $timeframe, "per_page" => $per_page, "page" => $page));
+			return $this->parsed_response ? $this->parsed_response['items']['item'] : false;
+		}
+
+		/* Authentication methods */
+		function auth_checkToken () {
+			/* https://www.flickr.com/services/api/flickr.auth.checkToken.html */
+			$this->request('flickr.auth.checkToken');
+			return $this->parsed_response ? $this->parsed_response['auth'] : false;
+		}
+
+		function auth_getFrob () {
+			/* https://www.flickr.com/services/api/flickr.auth.getFrob.html */
+			$this->request('flickr.auth.getFrob');
+			return $this->parsed_response ? $this->parsed_response['frob'] : false;
+		}
+
+		function auth_getFullToken ($mini_token) {
+			/* https://www.flickr.com/services/api/flickr.auth.getFullToken.html */
+			$this->request('flickr.auth.getFullToken', array('mini_token'=>$mini_token));
+			return $this->parsed_response ? $this->parsed_response['auth'] : false;
+		}
+
+		function auth_getToken ($frob) {
+			/* https://www.flickr.com/services/api/flickr.auth.getToken.html */
+			$this->request('flickr.auth.getToken', array('frob'=>$frob));
+			$_SESSION['phpFlickr_auth_token'] = $this->parsed_response['auth']['token'];
+			return $this->parsed_response ? $this->parsed_response['auth'] : false;
+		}
+
+		/* Blogs methods */
+		function blogs_getList ($service = NULL) {
+			/* https://www.flickr.com/services/api/flickr.blogs.getList.html */
+			$rsp = $this->call('flickr.blogs.getList', array('service' => $service));
+			return $rsp['blogs']['blog'];
+		}
+
+		function blogs_getServices () {
+			/* https://www.flickr.com/services/api/flickr.blogs.getServices.html */
+			return $this->call('flickr.blogs.getServices', array());
+		}
+
+		function blogs_postPhoto ($blog_id = NULL, $photo_id, $title, $description, $blog_password = NULL, $service = NULL) {
+			/* https://www.flickr.com/services/api/flickr.blogs.postPhoto.html */
+			return $this->call('flickr.blogs.postPhoto', array('blog_id' => $blog_id, 'photo_id' => $photo_id, 'title' => $title, 'description' => $description, 'blog_password' => $blog_password, 'service' => $service));
+		}
+
+		/* Collections Methods */
+		function collections_getInfo ($collection_id) {
+			/* https://www.flickr.com/services/api/flickr.collections.getInfo.html */
+			return $this->call('flickr.collections.getInfo', array('collection_id' => $collection_id));
+		}
+
+		function collections_getTree ($collection_id = NULL, $user_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.collections.getTree.html */
+			return $this->call('flickr.collections.getTree', array('collection_id' => $collection_id, 'user_id' => $user_id));
+		}
+
+		/* Commons Methods */
+		function commons_getInstitutions () {
+			/* https://www.flickr.com/services/api/flickr.commons.getInstitutions.html */
+			return $this->call('flickr.commons.getInstitutions', array());
+		}
+
+		/* Contacts Methods */
+		function contacts_getList ($filter = NULL, $page = NULL, $per_page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.contacts.getList.html */
+			$this->request('flickr.contacts.getList', array('filter'=>$filter, 'page'=>$page, 'per_page'=>$per_page));
+			return $this->parsed_response ? $this->parsed_response['contacts'] : false;
+		}
+
+		function contacts_getPublicList ($user_id, $page = NULL, $per_page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.contacts.getPublicList.html */
+			$this->request('flickr.contacts.getPublicList', array('user_id'=>$user_id, 'page'=>$page, 'per_page'=>$per_page));
+			return $this->parsed_response ? $this->parsed_response['contacts'] : false;
+		}
+
+		function contacts_getListRecentlyUploaded ($date_lastupload = NULL, $filter = NULL) {
+			/* https://www.flickr.com/services/api/flickr.contacts.getListRecentlyUploaded.html */
+			return $this->call('flickr.contacts.getListRecentlyUploaded', array('date_lastupload' => $date_lastupload, 'filter' => $filter));
+		}
+
+		/* Favorites Methods */
+		function favorites_add ($photo_id) {
+			/* https://www.flickr.com/services/api/flickr.favorites.add.html */
+			$this->request('flickr.favorites.add', array('photo_id'=>$photo_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function favorites_getList ($user_id = NULL, $jump_to = NULL, $min_fave_date = NULL, $max_fave_date = NULL, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.favorites.getList.html */
+			return $this->call('flickr.favorites.getList', array('user_id' => $user_id, 'jump_to' => $jump_to, 'min_fave_date' => $min_fave_date, 'max_fave_date' => $max_fave_date, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function favorites_getPublicList ($user_id, $jump_to = NULL, $min_fave_date = NULL, $max_fave_date = NULL, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.favorites.getPublicList.html */
+			return $this->call('flickr.favorites.getPublicList', array('user_id' => $user_id, 'jump_to' => $jump_to, 'min_fave_date' => $min_fave_date, 'max_fave_date' => $max_fave_date, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function favorites_remove ($photo_id, $user_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.favorites.remove.html */
+			$this->request("flickr.favorites.remove", array('photo_id' => $photo_id, 'user_id' => $user_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		/* Galleries Methods */
+		function galleries_addPhoto ($gallery_id, $photo_id, $comment = NULL) {
+			/* https://www.flickr.com/services/api/flickr.galleries.addPhoto.html */
+			return $this->call('flickr.galleries.addPhoto', array('gallery_id' => $gallery_id, 'photo_id' => $photo_id, 'comment' => $comment));
+		}
+
+		function galleries_create ($title, $description, $primary_photo_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.galleries.create.html */
+			return $this->call('flickr.galleries.create', array('title' => $title, 'description' => $description, 'primary_photo_id' => $primary_photo_id));
+		}
+
+		function galleries_editMeta ($gallery_id, $title, $description = NULL) {
+			/* https://www.flickr.com/services/api/flickr.galleries.editMeta.html */
+			return $this->call('flickr.galleries.editMeta', array('gallery_id' => $gallery_id, 'title' => $title, 'description' => $description));
+		}
+
+		function galleries_editPhoto ($gallery_id, $photo_id, $comment) {
+			/* https://www.flickr.com/services/api/flickr.galleries.editPhoto.html */
+			return $this->call('flickr.galleries.editPhoto', array('gallery_id' => $gallery_id, 'photo_id' => $photo_id, 'comment' => $comment));
+		}
+
+		function galleries_editPhotos ($gallery_id, $primary_photo_id, $photo_ids) {
+			/* https://www.flickr.com/services/api/flickr.galleries.editPhotos.html */
+			return $this->call('flickr.galleries.editPhotos', array('gallery_id' => $gallery_id, 'primary_photo_id' => $primary_photo_id, 'photo_ids' => $photo_ids));
+		}
+
+		function galleries_getInfo ($gallery_id) {
+			/* https://www.flickr.com/services/api/flickr.galleries.getInfo.html */
+			return $this->call('flickr.galleries.getInfo', array('gallery_id' => $gallery_id));
+		}
+
+		function galleries_getList ($user_id, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.galleries.getList.html */
+			return $this->call('flickr.galleries.getList', array('user_id' => $user_id, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function galleries_getListForPhoto ($photo_id, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.galleries.getListForPhoto.html */
+			return $this->call('flickr.galleries.getListForPhoto', array('photo_id' => $photo_id, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function galleries_getPhotos ($gallery_id, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.galleries.getPhotos.html */
+			return $this->call('flickr.galleries.getPhotos', array('gallery_id' => $gallery_id, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		/* Groups Methods */
+		function groups_browse ($cat_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.groups.browse.html */
+			$this->request("flickr.groups.browse", array("cat_id"=>$cat_id));
+			return $this->parsed_response ? $this->parsed_response['category'] : false;
+		}
+
+		function groups_getInfo ($group_id, $lang = NULL) {
+			/* https://www.flickr.com/services/api/flickr.groups.getInfo.html */
+			return $this->call('flickr.groups.getInfo', array('group_id' => $group_id, 'lang' => $lang));
+		}
+
+		function groups_search ($text, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.groups.search.html */
+			$this->request("flickr.groups.search", array("text"=>$text,"per_page"=>$per_page,"page"=>$page));
+			return $this->parsed_response ? $this->parsed_response['groups'] : false;
+		}
+
+		/* Groups Members Methods */
+		function groups_members_getList ($group_id, $membertypes = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.groups.members.getList.html */
+			return $this->call('flickr.groups.members.getList', array('group_id' => $group_id, 'membertypes' => $membertypes, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		/* Groups Pools Methods */
+		function groups_pools_add ($photo_id, $group_id) {
+			/* https://www.flickr.com/services/api/flickr.groups.pools.add.html */
+			$this->request("flickr.groups.pools.add", array("photo_id"=>$photo_id, "group_id"=>$group_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function groups_pools_getContext ($photo_id, $group_id, $num_prev = NULL, $num_next = NULL) {
+			/* https://www.flickr.com/services/api/flickr.groups.pools.getContext.html */
+			return $this->call('flickr.groups.pools.getContext', array('photo_id' => $photo_id, 'group_id' => $group_id, 'num_prev' => $num_prev, 'num_next' => $num_next));
+		}
+
+		function groups_pools_getGroups ($page = NULL, $per_page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.groups.pools.getGroups.html */
+			$this->request("flickr.groups.pools.getGroups", array('page'=>$page, 'per_page'=>$per_page));
+			return $this->parsed_response ? $this->parsed_response['groups'] : false;
+		}
+
+		function groups_pools_getPhotos ($group_id, $tags = NULL, $user_id = NULL, $jump_to = NULL, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.groups.pools.getPhotos.html */
+			if (is_array($extras)) {
+				$extras = implode(",", $extras);
+			}
+			return $this->call('flickr.groups.pools.getPhotos', array('group_id' => $group_id, 'tags' => $tags, 'user_id' => $user_id, 'jump_to' => $jump_to, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function groups_pools_remove ($photo_id, $group_id) {
+			/* https://www.flickr.com/services/api/flickr.groups.pools.remove.html */
+			$this->request("flickr.groups.pools.remove", array("photo_id"=>$photo_id, "group_id"=>$group_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		/* Interestingness methods */
+		function interestingness_getList ($date = NULL, $use_panda = NULL, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.interestingness.getList.html */
+			if (is_array($extras)) {
+				$extras = implode(",", $extras);
+			}
+
+			return $this->call('flickr.interestingness.getList', array('date' => $date, 'use_panda' => $use_panda, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		/* Machine Tag methods */
+		function machinetags_getNamespaces ($predicate = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.machinetags.getNamespaces.html */
+			return $this->call('flickr.machinetags.getNamespaces', array('predicate' => $predicate, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function machinetags_getPairs ($namespace = NULL, $predicate = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.machinetags.getPairs.html */
+			return $this->call('flickr.machinetags.getPairs', array('namespace' => $namespace, 'predicate' => $predicate, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function machinetags_getPredicates ($namespace = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.machinetags.getPredicates.html */
+			return $this->call('flickr.machinetags.getPredicates', array('namespace' => $namespace, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function machinetags_getRecentValues ($namespace = NULL, $predicate = NULL, $added_since = NULL) {
+			/* https://www.flickr.com/services/api/flickr.machinetags.getRecentValues.html */
+			return $this->call('flickr.machinetags.getRecentValues', array('namespace' => $namespace, 'predicate' => $predicate, 'added_since' => $added_since));
+		}
+
+		function machinetags_getValues ($namespace, $predicate, $per_page = NULL, $page = NULL, $usage = NULL) {
+			/* https://www.flickr.com/services/api/flickr.machinetags.getValues.html */
+			return $this->call('flickr.machinetags.getValues', array('namespace' => $namespace, 'predicate' => $predicate, 'per_page' => $per_page, 'page' => $page, 'usage' => $usage));
+		}
+
+		/* Panda methods */
+		function panda_getList () {
+			/* https://www.flickr.com/services/api/flickr.panda.getList.html */
+			return $this->call('flickr.panda.getList', array());
+		}
+
+		function panda_getPhotos ($panda_name, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.panda.getPhotos.html */
+			return $this->call('flickr.panda.getPhotos', array('panda_name' => $panda_name, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		/* People methods */
+		function people_findByEmail ($find_email) {
+			/* https://www.flickr.com/services/api/flickr.people.findByEmail.html */
+			$this->request("flickr.people.findByEmail", array("find_email"=>$find_email));
+			return $this->parsed_response ? $this->parsed_response['user'] : false;
+		}
+
+		function people_findByUsername ($username) {
+			/* https://www.flickr.com/services/api/flickr.people.findByUsername.html */
+			$this->request("flickr.people.findByUsername", array("username"=>$username));
+			return $this->parsed_response ? $this->parsed_response['user'] : false;
+		}
+
+		function people_getInfo ($user_id) {
+			/* https://www.flickr.com/services/api/flickr.people.getInfo.html */
+			$this->request("flickr.people.getInfo", array("user_id"=>$user_id));
+			return $this->parsed_response ? $this->parsed_response['person'] : false;
+		}
+
+		function people_getPhotos ($user_id, $args = array()) {
+			/* This function strays from the method of arguments that I've
+			 * used in the other functions for the fact that there are just
+			 * so many arguments to this API method. What you'll need to do
+			 * is pass an associative array to the function containing the
+			 * arguments you want to pass to the API.  For example:
+			 *   $photos = $f->photos_search(array("tags"=>"brown,cow", "tag_mode"=>"any"));
+			 * This will return photos tagged with either "brown" or "cow"
+			 * or both. See the API documentation (link below) for a full
+			 * list of arguments.
+			 */
+
+			 /* https://www.flickr.com/services/api/flickr.people.getPhotos.html */
+			return $this->call('flickr.people.getPhotos', array_merge(array('user_id' => $user_id), $args));
+		}
+
+		function people_getPhotosOf ($user_id, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.people.getPhotosOf.html */
+			return $this->call('flickr.people.getPhotosOf', array('user_id' => $user_id, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function people_getPublicGroups ($user_id) {
+			/* https://www.flickr.com/services/api/flickr.people.getPublicGroups.html */
+			$this->request("flickr.people.getPublicGroups", array("user_id"=>$user_id));
+			return $this->parsed_response ? $this->parsed_response['groups']['group'] : false;
+		}
+
+		function people_getPublicPhotos ($user_id, $safe_search = NULL, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.people.getPublicPhotos.html */
+			return $this->call('flickr.people.getPublicPhotos', array('user_id' => $user_id, 'safe_search' => $safe_search, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function people_getUploadStatus () {
+			/* https://www.flickr.com/services/api/flickr.people.getUploadStatus.html */
+			/* Requires Authentication */
+			$this->request("flickr.people.getUploadStatus");
+			return $this->parsed_response ? $this->parsed_response['user'] : false;
+		}
+
+
+		/* Photos Methods */
+		function photos_addTags ($photo_id, $tags) {
+			/* https://www.flickr.com/services/api/flickr.photos.addTags.html */
+			$this->request("flickr.photos.addTags", array("photo_id"=>$photo_id, "tags"=>$tags), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photos_delete ($photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.delete.html */
+			$this->request("flickr.photos.delete", array("photo_id"=>$photo_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photos_getAllContexts ($photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.getAllContexts.html */
+			$this->request("flickr.photos.getAllContexts", array("photo_id"=>$photo_id));
+			return $this->parsed_response ? $this->parsed_response : false;
+		}
+
+		function photos_getContactsPhotos ($count = NULL, $just_friends = NULL, $single_photo = NULL, $include_self = NULL, $extras = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.getContactsPhotos.html */
+			$this->request("flickr.photos.getContactsPhotos", array("count"=>$count, "just_friends"=>$just_friends, "single_photo"=>$single_photo, "include_self"=>$include_self, "extras"=>$extras));
+			return $this->parsed_response ? $this->parsed_response['photos']['photo'] : false;
+		}
+
+		function photos_getContactsPublicPhotos ($user_id, $count = NULL, $just_friends = NULL, $single_photo = NULL, $include_self = NULL, $extras = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.getContactsPublicPhotos.html */
+			$this->request("flickr.photos.getContactsPublicPhotos", array("user_id"=>$user_id, "count"=>$count, "just_friends"=>$just_friends, "single_photo"=>$single_photo, "include_self"=>$include_self, "extras"=>$extras));
+			return $this->parsed_response ? $this->parsed_response['photos']['photo'] : false;
+		}
+
+		function photos_getContext ($photo_id, $num_prev = NULL, $num_next = NULL, $extras = NULL, $order_by = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.getContext.html */
+			return $this->call('flickr.photos.getContext', array('photo_id' => $photo_id, 'num_prev' => $num_prev, 'num_next' => $num_next, 'extras' => $extras, 'order_by' => $order_by));
+		}
+
+		function photos_getCounts ($dates = NULL, $taken_dates = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.getCounts.html */
+			$this->request("flickr.photos.getCounts", array("dates"=>$dates, "taken_dates"=>$taken_dates));
+			return $this->parsed_response ? $this->parsed_response['photocounts']['photocount'] : false;
+		}
+
+		function photos_getExif ($photo_id, $secret = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.getExif.html */
+			$this->request("flickr.photos.getExif", array("photo_id"=>$photo_id, "secret"=>$secret));
+			return $this->parsed_response ? $this->parsed_response['photo'] : false;
+		}
+
+		function photos_getFavorites ($photo_id, $page = NULL, $per_page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.getFavorites.html */
+			$this->request("flickr.photos.getFavorites", array("photo_id"=>$photo_id, "page"=>$page, "per_page"=>$per_page));
+			return $this->parsed_response ? $this->parsed_response['photo'] : false;
+		}
+
+		function photos_getInfo ($photo_id, $secret = NULL, $humandates = NULL, $privacy_filter = NULL, $get_contexts = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.getInfo.html */
+			return $this->call('flickr.photos.getInfo', array('photo_id' => $photo_id, 'secret' => $secret, 'humandates' => $humandates, 'privacy_filter' => $privacy_filter, 'get_contexts' => $get_contexts));
+		}
+
+		function photos_getNotInSet ($max_upload_date = NULL, $min_taken_date = NULL, $max_taken_date = NULL, $privacy_filter = NULL, $media = NULL, $min_upload_date = NULL, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.getNotInSet.html */
+			return $this->call('flickr.photos.getNotInSet', array('max_upload_date' => $max_upload_date, 'min_taken_date' => $min_taken_date, 'max_taken_date' => $max_taken_date, 'privacy_filter' => $privacy_filter, 'media' => $media, 'min_upload_date' => $min_upload_date, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function photos_getPerms ($photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.getPerms.html */
+			$this->request("flickr.photos.getPerms", array("photo_id"=>$photo_id));
+			return $this->parsed_response ? $this->parsed_response['perms'] : false;
+		}
+
+		function photos_getRecent ($jump_to = NULL, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.getRecent.html */
+			if (is_array($extras)) {
+				$extras = implode(",", $extras);
+			}
+			return $this->call('flickr.photos.getRecent', array('jump_to' => $jump_to, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function photos_getSizes ($photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.getSizes.html */
+			$this->request("flickr.photos.getSizes", array("photo_id"=>$photo_id));
+			return $this->parsed_response ? $this->parsed_response['sizes']['size'] : false;
+		}
+
+		function photos_getUntagged ($min_upload_date = NULL, $max_upload_date = NULL, $min_taken_date = NULL, $max_taken_date = NULL, $privacy_filter = NULL, $media = NULL, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.getUntagged.html */
+			return $this->call('flickr.photos.getUntagged', array('min_upload_date' => $min_upload_date, 'max_upload_date' => $max_upload_date, 'min_taken_date' => $min_taken_date, 'max_taken_date' => $max_taken_date, 'privacy_filter' => $privacy_filter, 'media' => $media, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function photos_getWithGeoData ($args = array()) {
+			/* See the documentation included with the photos_search() function.
+			 * I'm using the same style of arguments for this function. The only
+			 * difference here is that this doesn't require any arguments. The
+			 * flickr.photos.search method requires at least one search parameter.
+			 */
+			/* https://www.flickr.com/services/api/flickr.photos.getWithGeoData.html */
+			$this->request("flickr.photos.getWithGeoData", $args);
+			return $this->parsed_response ? $this->parsed_response['photos'] : false;
+		}
+
+		function photos_getWithoutGeoData ($args = array()) {
+			/* See the documentation included with the photos_search() function.
+			 * I'm using the same style of arguments for this function. The only
+			 * difference here is that this doesn't require any arguments. The
+			 * flickr.photos.search method requires at least one search parameter.
+			 */
+			/* https://www.flickr.com/services/api/flickr.photos.getWithoutGeoData.html */
+			$this->request("flickr.photos.getWithoutGeoData", $args);
+			return $this->parsed_response ? $this->parsed_response['photos'] : false;
+		}
+
+		function photos_recentlyUpdated ($min_date, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.recentlyUpdated.html */
+			return $this->call('flickr.photos.recentlyUpdated', array('min_date' => $min_date, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function photos_removeTag ($tag_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.removeTag.html */
+			$this->request("flickr.photos.removeTag", array("tag_id"=>$tag_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photos_search ($args = array()) {
+			/* This function strays from the method of arguments that I've
+			 * used in the other functions for the fact that there are just
+			 * so many arguments to this API method. What you'll need to do
+			 * is pass an associative array to the function containing the
+			 * arguments you want to pass to the API.  For example:
+			 *   $photos = $f->photos_search(array("tags"=>"brown,cow", "tag_mode"=>"any"));
+			 * This will return photos tagged with either "brown" or "cow"
+			 * or both. See the API documentation (link below) for a full
+			 * list of arguments.
+			 */
+
+			/* https://www.flickr.com/services/api/flickr.photos.search.html */
+			$result = $this->request("flickr.photos.search", $args);
+			return ($this->parsed_response) ? $this->parsed_response['photos'] : false;
+		}
+
+		function photos_setContentType ($photo_id, $content_type) {
+			/* https://www.flickr.com/services/api/flickr.photos.setContentType.html */
+			return $this->call('flickr.photos.setContentType', array('photo_id' => $photo_id, 'content_type' => $content_type));
+		}
+
+		function photos_setDates ($photo_id, $date_posted = NULL, $date_taken = NULL, $date_taken_granularity = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.setDates.html */
+			$this->request("flickr.photos.setDates", array("photo_id"=>$photo_id, "date_posted"=>$date_posted, "date_taken"=>$date_taken, "date_taken_granularity"=>$date_taken_granularity), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photos_setMeta ($photo_id, $title, $description) {
+			/* https://www.flickr.com/services/api/flickr.photos.setMeta.html */
+			$this->request("flickr.photos.setMeta", array("photo_id"=>$photo_id, "title"=>$title, "description"=>$description), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photos_setPerms ($photo_id, $is_public, $is_friend, $is_family, $perm_comment, $perm_addmeta) {
+			/* https://www.flickr.com/services/api/flickr.photos.setPerms.html */
+			$this->request("flickr.photos.setPerms", array("photo_id"=>$photo_id, "is_public"=>$is_public, "is_friend"=>$is_friend, "is_family"=>$is_family, "perm_comment"=>$perm_comment, "perm_addmeta"=>$perm_addmeta), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photos_setSafetyLevel ($photo_id, $safety_level = NULL, $hidden = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.setSafetyLevel.html */
+			return $this->call('flickr.photos.setSafetyLevel', array('photo_id' => $photo_id, 'safety_level' => $safety_level, 'hidden' => $hidden));
+		}
+
+		function photos_setTags ($photo_id, $tags) {
+			/* https://www.flickr.com/services/api/flickr.photos.setTags.html */
+			$this->request("flickr.photos.setTags", array("photo_id"=>$photo_id, "tags"=>$tags), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		/* Photos - Comments Methods */
+		function photos_comments_addComment ($photo_id, $comment_text) {
+			/* https://www.flickr.com/services/api/flickr.photos.comments.addComment.html */
+			$this->request("flickr.photos.comments.addComment", array("photo_id" => $photo_id, "comment_text"=>$comment_text), TRUE);
+			return $this->parsed_response ? $this->parsed_response['comment'] : false;
+		}
+
+		function photos_comments_deleteComment ($comment_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.comments.deleteComment.html */
+			$this->request("flickr.photos.comments.deleteComment", array("comment_id" => $comment_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photos_comments_editComment ($comment_id, $comment_text) {
+			/* https://www.flickr.com/services/api/flickr.photos.comments.editComment.html */
+			$this->request("flickr.photos.comments.editComment", array("comment_id" => $comment_id, "comment_text"=>$comment_text), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photos_comments_getList ($photo_id, $min_comment_date = NULL, $max_comment_date = NULL, $page = NULL, $per_page = NULL, $include_faves = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.comments.getList.html */
+			return $this->call('flickr.photos.comments.getList', array('photo_id' => $photo_id, 'min_comment_date' => $min_comment_date, 'max_comment_date' => $max_comment_date, 'page' => $page, 'per_page' => $per_page, 'include_faves' => $include_faves));
+		}
+
+		function photos_comments_getRecentForContacts ($date_lastcomment = NULL, $contacts_filter = NULL, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.comments.getRecentForContacts.html */
+			return $this->call('flickr.photos.comments.getRecentForContacts', array('date_lastcomment' => $date_lastcomment, 'contacts_filter' => $contacts_filter, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		/* Photos - Geo Methods */
+		function photos_geo_batchCorrectLocation ($lat, $lon, $accuracy, $place_id = NULL, $woe_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.geo.batchCorrectLocation.html */
+			return $this->call('flickr.photos.geo.batchCorrectLocation', array('lat' => $lat, 'lon' => $lon, 'accuracy' => $accuracy, 'place_id' => $place_id, 'woe_id' => $woe_id));
+		}
+
+		function photos_geo_correctLocation ($photo_id, $place_id = NULL, $woe_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.geo.correctLocation.html */
+			return $this->call('flickr.photos.geo.correctLocation', array('photo_id' => $photo_id, 'place_id' => $place_id, 'woe_id' => $woe_id));
+		}
+
+		function photos_geo_getLocation ($photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.geo.getLocation.html */
+			$this->request("flickr.photos.geo.getLocation", array("photo_id"=>$photo_id));
+			return $this->parsed_response ? $this->parsed_response['photo'] : false;
+		}
+
+		function photos_geo_getPerms ($photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.geo.getPerms.html */
+			$this->request("flickr.photos.geo.getPerms", array("photo_id"=>$photo_id));
+			return $this->parsed_response ? $this->parsed_response['perms'] : false;
+		}
+
+		function photos_geo_photosForLocation ($lat, $lon, $accuracy = NULL, $extras = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.geo.photosForLocation.html */
+			return $this->call('flickr.photos.geo.photosForLocation', array('lat' => $lat, 'lon' => $lon, 'accuracy' => $accuracy, 'extras' => $extras, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function photos_geo_removeLocation ($photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.geo.removeLocation.html */
+			$this->request("flickr.photos.geo.removeLocation", array("photo_id"=>$photo_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photos_geo_setContext ($photo_id, $context) {
+			/* https://www.flickr.com/services/api/flickr.photos.geo.setContext.html */
+			return $this->call('flickr.photos.geo.setContext', array('photo_id' => $photo_id, 'context' => $context));
+		}
+
+		function photos_geo_setLocation ($photo_id, $lat, $lon, $accuracy = NULL, $context = NULL, $bookmark_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.geo.setLocation.html */
+			return $this->call('flickr.photos.geo.setLocation', array('photo_id' => $photo_id, 'lat' => $lat, 'lon' => $lon, 'accuracy' => $accuracy, 'context' => $context, 'bookmark_id' => $bookmark_id));
+		}
+
+		function photos_geo_setPerms ($is_public, $is_contact, $is_friend, $is_family, $photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.geo.setPerms.html */
+			return $this->call('flickr.photos.geo.setPerms', array('is_public' => $is_public, 'is_contact' => $is_contact, 'is_friend' => $is_friend, 'is_family' => $is_family, 'photo_id' => $photo_id));
+		}
+
+		/* Photos - Licenses Methods */
+		function photos_licenses_getInfo () {
+			/* https://www.flickr.com/services/api/flickr.photos.licenses.getInfo.html */
+			$this->request("flickr.photos.licenses.getInfo");
+			return $this->parsed_response ? $this->parsed_response['licenses']['license'] : false;
+		}
+
+		function photos_licenses_setLicense ($photo_id, $license_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.licenses.setLicense.html */
+			/* Requires Authentication */
+			$this->request("flickr.photos.licenses.setLicense", array("photo_id"=>$photo_id, "license_id"=>$license_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		/* Photos - Notes Methods */
+		function photos_notes_add ($photo_id, $note_x, $note_y, $note_w, $note_h, $note_text) {
+			/* https://www.flickr.com/services/api/flickr.photos.notes.add.html */
+			$this->request("flickr.photos.notes.add", array("photo_id" => $photo_id, "note_x" => $note_x, "note_y" => $note_y, "note_w" => $note_w, "note_h" => $note_h, "note_text" => $note_text), TRUE);
+			return $this->parsed_response ? $this->parsed_response['note'] : false;
+		}
+
+		function photos_notes_delete ($note_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.notes.delete.html */
+			$this->request("flickr.photos.notes.delete", array("note_id" => $note_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photos_notes_edit ($note_id, $note_x, $note_y, $note_w, $note_h, $note_text) {
+			/* https://www.flickr.com/services/api/flickr.photos.notes.edit.html */
+			$this->request("flickr.photos.notes.edit", array("note_id" => $note_id, "note_x" => $note_x, "note_y" => $note_y, "note_w" => $note_w, "note_h" => $note_h, "note_text" => $note_text), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		/* Photos - Transform Methods */
+		function photos_transform_rotate ($photo_id, $degrees) {
+			/* https://www.flickr.com/services/api/flickr.photos.transform.rotate.html */
+			$this->request("flickr.photos.transform.rotate", array("photo_id" => $photo_id, "degrees" => $degrees), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		/* Photos - People Methods */
+		function photos_people_add ($photo_id, $user_id, $person_x = NULL, $person_y = NULL, $person_w = NULL, $person_h = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.people.add.html */
+			return $this->call('flickr.photos.people.add', array('photo_id' => $photo_id, 'user_id' => $user_id, 'person_x' => $person_x, 'person_y' => $person_y, 'person_w' => $person_w, 'person_h' => $person_h));
+		}
+
+		function photos_people_delete ($photo_id, $user_id, $email = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.people.delete.html */
+			return $this->call('flickr.photos.people.delete', array('photo_id' => $photo_id, 'user_id' => $user_id, 'email' => $email));
+		}
+
+		function photos_people_deleteCoords ($photo_id, $user_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.people.deleteCoords.html */
+			return $this->call('flickr.photos.people.deleteCoords', array('photo_id' => $photo_id, 'user_id' => $user_id));
+		}
+
+		function photos_people_editCoords ($photo_id, $user_id, $person_x, $person_y, $person_w, $person_h, $email = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photos.people.editCoords.html */
+			return $this->call('flickr.photos.people.editCoords', array('photo_id' => $photo_id, 'user_id' => $user_id, 'person_x' => $person_x, 'person_y' => $person_y, 'person_w' => $person_w, 'person_h' => $person_h, 'email' => $email));
+		}
+
+		function photos_people_getList ($photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photos.people.getList.html */
+			return $this->call('flickr.photos.people.getList', array('photo_id' => $photo_id));
+		}
+
+		/* Photos - Upload Methods */
+		function photos_upload_checkTickets ($tickets) {
+			/* https://www.flickr.com/services/api/flickr.photos.upload.checkTickets.html */
+			if (is_array($tickets)) {
+				$tickets = implode(",", $tickets);
+			}
+			$this->request("flickr.photos.upload.checkTickets", array("tickets" => $tickets), TRUE);
+			return $this->parsed_response ? $this->parsed_response['uploader']['ticket'] : false;
+		}
+
+		/* Photosets Methods */
+		function photosets_addPhoto ($photoset_id, $photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photosets.addPhoto.html */
+			$this->request("flickr.photosets.addPhoto", array("photoset_id" => $photoset_id, "photo_id" => $photo_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photosets_create ($title, $description, $primary_photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photosets.create.html */
+			$this->request("flickr.photosets.create", array("title" => $title, "primary_photo_id" => $primary_photo_id, "description" => $description), TRUE);
+			return $this->parsed_response ? $this->parsed_response['photoset'] : false;
+		}
+
+		function photosets_delete ($photoset_id) {
+			/* https://www.flickr.com/services/api/flickr.photosets.delete.html */
+			$this->request("flickr.photosets.delete", array("photoset_id" => $photoset_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photosets_editMeta ($photoset_id, $title, $description = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photosets.editMeta.html */
+			$this->request("flickr.photosets.editMeta", array("photoset_id" => $photoset_id, "title" => $title, "description" => $description), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photosets_editPhotos ($photoset_id, $primary_photo_id, $photo_ids) {
+			/* https://www.flickr.com/services/api/flickr.photosets.editPhotos.html */
+			$this->request("flickr.photosets.editPhotos", array("photoset_id" => $photoset_id, "primary_photo_id" => $primary_photo_id, "photo_ids" => $photo_ids), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photosets_getContext ($photo_id, $photoset_id, $num_prev = NULL, $num_next = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photosets.getContext.html */
+			return $this->call('flickr.photosets.getContext', array('photo_id' => $photo_id, 'photoset_id' => $photoset_id, 'num_prev' => $num_prev, 'num_next' => $num_next));
+		}
+
+		function photosets_getInfo ($photoset_id) {
+			/* https://www.flickr.com/services/api/flickr.photosets.getInfo.html */
+			$this->request("flickr.photosets.getInfo", array("photoset_id" => $photoset_id));
+			return $this->parsed_response ? $this->parsed_response['photoset'] : false;
+		}
+
+		function photosets_getList ($user_id = NULL, $page = NULL, $per_page = NULL, $primary_photo_extras = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photosets.getList.html */
+			$this->request("flickr.photosets.getList", array("user_id" => $user_id, 'page' => $page, 'per_page' => $per_page, 'primary_photo_extras' => $primary_photo_extras));
+			return $this->parsed_response ? $this->parsed_response['photosets'] : false;
+		}
+
+		function photosets_getPhotos ($photoset_id, $extras = NULL, $privacy_filter = NULL, $per_page = NULL, $page = NULL, $media = NULL) {
+			/* https://www.flickr.com/services/api/flickr.photosets.getPhotos.html */
+			return $this->call('flickr.photosets.getPhotos', array('photoset_id' => $photoset_id, 'extras' => $extras, 'privacy_filter' => $privacy_filter, 'per_page' => $per_page, 'page' => $page, 'media' => $media));
+		}
+
+		function photosets_orderSets ($photoset_ids) {
+			/* https://www.flickr.com/services/api/flickr.photosets.orderSets.html */
+			if (is_array($photoset_ids)) {
+				$photoset_ids = implode(",", $photoset_ids);
+			}
+			$this->request("flickr.photosets.orderSets", array("photoset_ids" => $photoset_ids), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photosets_removePhoto ($photoset_id, $photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photosets.removePhoto.html */
+			$this->request("flickr.photosets.removePhoto", array("photoset_id" => $photoset_id, "photo_id" => $photo_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photosets_removePhotos ($photoset_id, $photo_ids) {
+			/* https://www.flickr.com/services/api/flickr.photosets.removePhotos.html */
+			return $this->call('flickr.photosets.removePhotos', array('photoset_id' => $photoset_id, 'photo_ids' => $photo_ids));
+		}
+
+		function photosets_reorderPhotos ($photoset_id, $photo_ids) {
+			/* https://www.flickr.com/services/api/flickr.photosets.reorderPhotos.html */
+			return $this->call('flickr.photosets.reorderPhotos', array('photoset_id' => $photoset_id, 'photo_ids' => $photo_ids));
+		}
+
+		function photosets_setPrimaryPhoto ($photoset_id, $photo_id) {
+			/* https://www.flickr.com/services/api/flickr.photosets.setPrimaryPhoto.html */
+			return $this->call('flickr.photosets.setPrimaryPhoto', array('photoset_id' => $photoset_id, 'photo_id' => $photo_id));
+		}
+
+		/* Photosets Comments Methods */
+		function photosets_comments_addComment ($photoset_id, $comment_text) {
+			/* https://www.flickr.com/services/api/flickr.photosets.comments.addComment.html */
+			$this->request("flickr.photosets.comments.addComment", array("photoset_id" => $photoset_id, "comment_text"=>$comment_text), TRUE);
+			return $this->parsed_response ? $this->parsed_response['comment'] : false;
+		}
+
+		function photosets_comments_deleteComment ($comment_id) {
+			/* https://www.flickr.com/services/api/flickr.photosets.comments.deleteComment.html */
+			$this->request("flickr.photosets.comments.deleteComment", array("comment_id" => $comment_id), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photosets_comments_editComment ($comment_id, $comment_text) {
+			/* https://www.flickr.com/services/api/flickr.photosets.comments.editComment.html */
+			$this->request("flickr.photosets.comments.editComment", array("comment_id" => $comment_id, "comment_text"=>$comment_text), TRUE);
+			return $this->parsed_response ? true : false;
+		}
+
+		function photosets_comments_getList ($photoset_id) {
+			/* https://www.flickr.com/services/api/flickr.photosets.comments.getList.html */
+			$this->request("flickr.photosets.comments.getList", array("photoset_id"=>$photoset_id));
+			return $this->parsed_response ? $this->parsed_response['comments'] : false;
+		}
+
+		/* Places Methods */
+		function places_find ($query) {
+			/* https://www.flickr.com/services/api/flickr.places.find.html */
+			return $this->call('flickr.places.find', array('query' => $query));
+		}
+
+		function places_findByLatLon ($lat, $lon, $accuracy = NULL) {
+			/* https://www.flickr.com/services/api/flickr.places.findByLatLon.html */
+			return $this->call('flickr.places.findByLatLon', array('lat' => $lat, 'lon' => $lon, 'accuracy' => $accuracy));
+		}
+
+		function places_getChildrenWithPhotosPublic ($place_id = NULL, $woe_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.places.getChildrenWithPhotosPublic.html */
+			return $this->call('flickr.places.getChildrenWithPhotosPublic', array('place_id' => $place_id, 'woe_id' => $woe_id));
+		}
+
+		function places_getInfo ($place_id = NULL, $woe_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.places.getInfo.html */
+			return $this->call('flickr.places.getInfo', array('place_id' => $place_id, 'woe_id' => $woe_id));
+		}
+
+		function places_getInfoByUrl ($url) {
+			/* https://www.flickr.com/services/api/flickr.places.getInfoByUrl.html */
+			return $this->call('flickr.places.getInfoByUrl', array('url' => $url));
+		}
+
+		function places_getPlaceTypes () {
+			/* https://www.flickr.com/services/api/flickr.places.getPlaceTypes.html */
+			return $this->call('flickr.places.getPlaceTypes', array());
+		}
+
+		function places_getShapeHistory ($place_id = NULL, $woe_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.places.getShapeHistory.html */
+			return $this->call('flickr.places.getShapeHistory', array('place_id' => $place_id, 'woe_id' => $woe_id));
+		}
+
+		function places_getTopPlacesList ($place_type_id, $date = NULL, $woe_id = NULL, $place_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.places.getTopPlacesList.html */
+			return $this->call('flickr.places.getTopPlacesList', array('place_type_id' => $place_type_id, 'date' => $date, 'woe_id' => $woe_id, 'place_id' => $place_id));
+		}
+
+		function places_placesForBoundingBox ($bbox, $place_type = NULL, $place_type_id = NULL, $recursive = NULL) {
+			/* https://www.flickr.com/services/api/flickr.places.placesForBoundingBox.html */
+			return $this->call('flickr.places.placesForBoundingBox', array('bbox' => $bbox, 'place_type' => $place_type, 'place_type_id' => $place_type_id, 'recursive' => $recursive));
+		}
+
+		function places_placesForContacts ($place_type = NULL, $place_type_id = NULL, $woe_id = NULL, $place_id = NULL, $threshold = NULL, $contacts = NULL, $min_upload_date = NULL, $max_upload_date = NULL, $min_taken_date = NULL, $max_taken_date = NULL) {
+			/* https://www.flickr.com/services/api/flickr.places.placesForContacts.html */
+			return $this->call('flickr.places.placesForContacts', array('place_type' => $place_type, 'place_type_id' => $place_type_id, 'woe_id' => $woe_id, 'place_id' => $place_id, 'threshold' => $threshold, 'contacts' => $contacts, 'min_upload_date' => $min_upload_date, 'max_upload_date' => $max_upload_date, 'min_taken_date' => $min_taken_date, 'max_taken_date' => $max_taken_date));
+		}
+
+		function places_placesForTags ($place_type_id, $woe_id = NULL, $place_id = NULL, $threshold = NULL, $tags = NULL, $tag_mode = NULL, $machine_tags = NULL, $machine_tag_mode = NULL, $min_upload_date = NULL, $max_upload_date = NULL, $min_taken_date = NULL, $max_taken_date = NULL) {
+			/* https://www.flickr.com/services/api/flickr.places.placesForTags.html */
+			return $this->call('flickr.places.placesForTags', array('place_type_id' => $place_type_id, 'woe_id' => $woe_id, 'place_id' => $place_id, 'threshold' => $threshold, 'tags' => $tags, 'tag_mode' => $tag_mode, 'machine_tags' => $machine_tags, 'machine_tag_mode' => $machine_tag_mode, 'min_upload_date' => $min_upload_date, 'max_upload_date' => $max_upload_date, 'min_taken_date' => $min_taken_date, 'max_taken_date' => $max_taken_date));
+		}
+
+		function places_placesForUser ($place_type_id = NULL, $place_type = NULL, $woe_id = NULL, $place_id = NULL, $threshold = NULL, $min_upload_date = NULL, $max_upload_date = NULL, $min_taken_date = NULL, $max_taken_date = NULL) {
+			/* https://www.flickr.com/services/api/flickr.places.placesForUser.html */
+			return $this->call('flickr.places.placesForUser', array('place_type_id' => $place_type_id, 'place_type' => $place_type, 'woe_id' => $woe_id, 'place_id' => $place_id, 'threshold' => $threshold, 'min_upload_date' => $min_upload_date, 'max_upload_date' => $max_upload_date, 'min_taken_date' => $min_taken_date, 'max_taken_date' => $max_taken_date));
+		}
+
+		function places_resolvePlaceId ($place_id) {
+			/* https://www.flickr.com/services/api/flickr.places.resolvePlaceId.html */
+			$rsp = $this->call('flickr.places.resolvePlaceId', array('place_id' => $place_id));
+			return $rsp ? $rsp['location'] : $rsp;
+		}
+
+		function places_resolvePlaceURL ($url) {
+			/* https://www.flickr.com/services/api/flickr.places.resolvePlaceURL.html */
+			$rsp = $this->call('flickr.places.resolvePlaceURL', array('url' => $url));
+			return $rsp ? $rsp['location'] : $rsp;
+		}
+
+		function places_tagsForPlace ($woe_id = NULL, $place_id = NULL, $min_upload_date = NULL, $max_upload_date = NULL, $min_taken_date = NULL, $max_taken_date = NULL) {
+			/* https://www.flickr.com/services/api/flickr.places.tagsForPlace.html */
+			return $this->call('flickr.places.tagsForPlace', array('woe_id' => $woe_id, 'place_id' => $place_id, 'min_upload_date' => $min_upload_date, 'max_upload_date' => $max_upload_date, 'min_taken_date' => $min_taken_date, 'max_taken_date' => $max_taken_date));
+		}
+
+		/* Prefs Methods */
+		function prefs_getContentType () {
+			/* https://www.flickr.com/services/api/flickr.prefs.getContentType.html */
+			$rsp = $this->call('flickr.prefs.getContentType', array());
+			return $rsp ? $rsp['person'] : $rsp;
+		}
+
+		function prefs_getGeoPerms () {
+			/* https://www.flickr.com/services/api/flickr.prefs.getGeoPerms.html */
+			return $this->call('flickr.prefs.getGeoPerms', array());
+		}
+
+		function prefs_getHidden () {
+			/* https://www.flickr.com/services/api/flickr.prefs.getHidden.html */
+			$rsp = $this->call('flickr.prefs.getHidden', array());
+			return $rsp ? $rsp['person'] : $rsp;
+		}
+
+		function prefs_getPrivacy () {
+			/* https://www.flickr.com/services/api/flickr.prefs.getPrivacy.html */
+			$rsp = $this->call('flickr.prefs.getPrivacy', array());
+			return $rsp ? $rsp['person'] : $rsp;
+		}
+
+		function prefs_getSafetyLevel () {
+			/* https://www.flickr.com/services/api/flickr.prefs.getSafetyLevel.html */
+			$rsp = $this->call('flickr.prefs.getSafetyLevel', array());
+			return $rsp ? $rsp['person'] : $rsp;
+		}
+
+		/* Reflection Methods */
+		function reflection_getMethodInfo ($method_name) {
+			/* https://www.flickr.com/services/api/flickr.reflection.getMethodInfo.html */
+			$this->request("flickr.reflection.getMethodInfo", array("method_name" => $method_name));
+			return $this->parsed_response ? $this->parsed_response : false;
+		}
+
+		function reflection_getMethods () {
+			/* https://www.flickr.com/services/api/flickr.reflection.getMethods.html */
+			$this->request("flickr.reflection.getMethods");
+			return $this->parsed_response ? $this->parsed_response['methods']['method'] : false;
+		}
+
+		/* Stats Methods */
+		function stats_getCollectionDomains ($date, $collection_id = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.stats.getCollectionDomains.html */
+			return $this->call('flickr.stats.getCollectionDomains', array('date' => $date, 'collection_id' => $collection_id, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function stats_getCollectionReferrers ($date, $domain, $collection_id = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.stats.getCollectionReferrers.html */
+			return $this->call('flickr.stats.getCollectionReferrers', array('date' => $date, 'domain' => $domain, 'collection_id' => $collection_id, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function stats_getCollectionStats ($date, $collection_id) {
+			/* https://www.flickr.com/services/api/flickr.stats.getCollectionStats.html */
+			return $this->call('flickr.stats.getCollectionStats', array('date' => $date, 'collection_id' => $collection_id));
+		}
+
+		function stats_getCSVFiles () {
+			/* https://www.flickr.com/services/api/flickr.stats.getCSVFiles.html */
+			return $this->call('flickr.stats.getCSVFiles', array());
+		}
+
+		function stats_getPhotoDomains ($date, $photo_id = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.stats.getPhotoDomains.html */
+			return $this->call('flickr.stats.getPhotoDomains', array('date' => $date, 'photo_id' => $photo_id, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function stats_getPhotoReferrers ($date, $domain, $photo_id = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.stats.getPhotoReferrers.html */
+			return $this->call('flickr.stats.getPhotoReferrers', array('date' => $date, 'domain' => $domain, 'photo_id' => $photo_id, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function stats_getPhotosetDomains ($date, $photoset_id = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.stats.getPhotosetDomains.html */
+			return $this->call('flickr.stats.getPhotosetDomains', array('date' => $date, 'photoset_id' => $photoset_id, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function stats_getPhotosetReferrers ($date, $domain, $photoset_id = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.stats.getPhotosetReferrers.html */
+			return $this->call('flickr.stats.getPhotosetReferrers', array('date' => $date, 'domain' => $domain, 'photoset_id' => $photoset_id, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function stats_getPhotosetStats ($date, $photoset_id) {
+			/* https://www.flickr.com/services/api/flickr.stats.getPhotosetStats.html */
+			return $this->call('flickr.stats.getPhotosetStats', array('date' => $date, 'photoset_id' => $photoset_id));
+		}
+
+		function stats_getPhotoStats ($date, $photo_id) {
+			/* https://www.flickr.com/services/api/flickr.stats.getPhotoStats.html */
+			return $this->call('flickr.stats.getPhotoStats', array('date' => $date, 'photo_id' => $photo_id));
+		}
+
+		function stats_getPhotostreamDomains ($date, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.stats.getPhotostreamDomains.html */
+			return $this->call('flickr.stats.getPhotostreamDomains', array('date' => $date, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function stats_getPhotostreamReferrers ($date, $domain, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.stats.getPhotostreamReferrers.html */
+			return $this->call('flickr.stats.getPhotostreamReferrers', array('date' => $date, 'domain' => $domain, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function stats_getPhotostreamStats ($date) {
+			/* https://www.flickr.com/services/api/flickr.stats.getPhotostreamStats.html */
+			return $this->call('flickr.stats.getPhotostreamStats', array('date' => $date));
+		}
+
+		function stats_getPopularPhotos ($date = NULL, $sort = NULL, $per_page = NULL, $page = NULL) {
+			/* https://www.flickr.com/services/api/flickr.stats.getPopularPhotos.html */
+			return $this->call('flickr.stats.getPopularPhotos', array('date' => $date, 'sort' => $sort, 'per_page' => $per_page, 'page' => $page));
+		}
+
+		function stats_getTotalViews ($date = NULL) {
+			/* https://www.flickr.com/services/api/flickr.stats.getTotalViews.html */
+			return $this->call('flickr.stats.getTotalViews', array('date' => $date));
+		}
+
+		/* Tags Methods */
+		function tags_getClusterPhotos ($tag, $cluster_id) {
+			/* https://www.flickr.com/services/api/flickr.tags.getClusterPhotos.html */
+			return $this->call('flickr.tags.getClusterPhotos', array('tag' => $tag, 'cluster_id' => $cluster_id));
+		}
+
+		function tags_getClusters ($tag) {
+			/* https://www.flickr.com/services/api/flickr.tags.getClusters.html */
+			return $this->call('flickr.tags.getClusters', array('tag' => $tag));
+		}
+
+		function tags_getHotList ($period = NULL, $count = NULL) {
+			/* https://www.flickr.com/services/api/flickr.tags.getHotList.html */
+			$this->request("flickr.tags.getHotList", array("period" => $period, "count" => $count));
+			return $this->parsed_response ? $this->parsed_response['hottags'] : false;
+		}
+
+		function tags_getListPhoto ($photo_id) {
+			/* https://www.flickr.com/services/api/flickr.tags.getListPhoto.html */
+			$this->request("flickr.tags.getListPhoto", array("photo_id" => $photo_id));
+			return $this->parsed_response ? $this->parsed_response['photo']['tags']['tag'] : false;
+		}
+
+		function tags_getListUser ($user_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.tags.getListUser.html */
+			$this->request("flickr.tags.getListUser", array("user_id" => $user_id));
+			return $this->parsed_response ? $this->parsed_response['who']['tags']['tag'] : false;
+		}
+
+		function tags_getListUserPopular ($user_id = NULL, $count = NULL) {
+			/* https://www.flickr.com/services/api/flickr.tags.getListUserPopular.html */
+			$this->request("flickr.tags.getListUserPopular", array("user_id" => $user_id, "count" => $count));
+			return $this->parsed_response ? $this->parsed_response['who']['tags']['tag'] : false;
+		}
+
+		function tags_getListUserRaw ($tag = NULL) {
+			/* https://www.flickr.com/services/api/flickr.tags.getListUserRaw.html */
+			return $this->call('flickr.tags.getListUserRaw', array('tag' => $tag));
+		}
+
+		function tags_getRelated ($tag) {
+			/* https://www.flickr.com/services/api/flickr.tags.getRelated.html */
+			$this->request("flickr.tags.getRelated", array("tag" => $tag));
+			return $this->parsed_response ? $this->parsed_response['tags'] : false;
+		}
+
+		function test_echo ($args = array()) {
+			/* https://www.flickr.com/services/api/flickr.test.echo.html */
+			$this->request("flickr.test.echo", $args);
+			return $this->parsed_response ? $this->parsed_response : false;
+		}
+
+		function test_login () {
+			/* https://www.flickr.com/services/api/flickr.test.login.html */
+			$this->request("flickr.test.login");
+			return $this->parsed_response ? $this->parsed_response['user'] : false;
+		}
+
+		function urls_getGroup ($group_id) {
+			/* https://www.flickr.com/services/api/flickr.urls.getGroup.html */
+			$this->request("flickr.urls.getGroup", array("group_id"=>$group_id));
+			return $this->parsed_response ? $this->parsed_response['group']['url'] : false;
+		}
+
+		function urls_getUserPhotos ($user_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.urls.getUserPhotos.html */
+			$this->request("flickr.urls.getUserPhotos", array("user_id"=>$user_id));
+			return $this->parsed_response ? $this->parsed_response['user']['url'] : false;
+		}
+
+		function urls_getUserProfile ($user_id = NULL) {
+			/* https://www.flickr.com/services/api/flickr.urls.getUserProfile.html */
+			$this->request("flickr.urls.getUserProfile", array("user_id"=>$user_id));
+			return $this->parsed_response ? $this->parsed_response['user']['url'] : false;
+		}
+
+		function urls_lookupGallery ($url) {
+			/* https://www.flickr.com/services/api/flickr.urls.lookupGallery.html */
+			return $this->call('flickr.urls.lookupGallery', array('url' => $url));
+		}
+
+		function urls_lookupGroup ($url) {
+			/* https://www.flickr.com/services/api/flickr.urls.lookupGroup.html */
+			$this->request("flickr.urls.lookupGroup", array("url"=>$url));
+			return $this->parsed_response ? $this->parsed_response['group'] : false;
+		}
+
+		function urls_lookupUser ($url) {
+			/* https://www.flickr.com/services/api/flickr.photos.notes.edit.html */
+			$this->request("flickr.urls.lookupUser", array("url"=>$url));
+			return $this->parsed_response ? $this->parsed_response['user'] : false;
+		}
+	}
 }
 
+if ( !class_exists('phpFlickr_pager') ) {
+	class phpFlickr_pager {
+		var $phpFlickr, $per_page, $method, $args, $results, $global_phpFlickr;
+		var $total = null, $page = 0, $pages = null, $photos, $_extra = null;
+
+
+		function phpFlickr_pager($phpFlickr, $method = null, $args = null, $per_page = 30) {
+			$this->per_page = $per_page;
+			$this->method = $method;
+			$this->args = $args;
+			$this->set_phpFlickr($phpFlickr);
+		}
+
+		function set_phpFlickr($phpFlickr) {
+			if ( is_a($phpFlickr, 'phpFlickr') ) {
+				$this->phpFlickr = $phpFlickr;
+				if ( $this->phpFlickr->cache ) {
+					$this->args['per_page'] = 500;
+				} else {
+					$this->args['per_page'] = (int) $this->per_page;
+				}
+			}
+		}
+
+		function __sleep() {
+			return array(
+				'method',
+				'args',
+				'per_page',
+				'page',
+				'_extra',
+			);
+		}
+
+		function load($page) {
+			$allowed_methods = array(
+				'flickr.photos.search' => 'photos',
+				'flickr.photosets.getPhotos' => 'photoset',
+			);
+			if ( !in_array($this->method, array_keys($allowed_methods)) ) return false;
+
+			if ( $this->phpFlickr->cache ) {
+				$min = ($page - 1) * $this->per_page;
+				$max = $page * $this->per_page - 1;
+				if ( floor($min/500) == floor($max/500) ) {
+					$this->args['page'] = floor($min/500) + 1;
+					$this->results = $this->phpFlickr->call($this->method, $this->args);
+					if ( $this->results ) {
+						$this->results = $this->results[$allowed_methods[$this->method]];
+						$this->photos = array_slice($this->results['photo'], $min % 500, $this->per_page);
+						$this->total = $this->results['total'];
+						$this->pages = ceil($this->results['total'] / $this->per_page);
+						return true;
+					} else {
+						return false;
+					}
+				} else {
+					$this->args['page'] = floor($min/500) + 1;
+					$this->results = $this->phpFlickr->call($this->method, $this->args);
+					if ( $this->results ) {
+						$this->results = $this->results[$allowed_methods[$this->method]];
+
+						$this->photos = array_slice($this->results['photo'], $min % 500);
+						$this->total = $this->results['total'];
+						$this->pages = ceil($this->results['total'] / $this->per_page);
+
+						$this->args['page'] = floor($min/500) + 2;
+						$this->results = $this->phpFlickr->call($this->method, $this->args);
+						if ( $this->results ) {
+							$this->results = $this->results[$allowed_methods[$this->method]];
+							$this->photos = array_merge($this->photos, array_slice($this->results['photo'], 0, $max % 500 + 1));
+						}
+						return true;
+					} else {
+						return false;
+					}
+
+				}
+			} else {
+				$this->args['page'] = $page;
+				$this->results = $this->phpFlickr->call($this->method, $this->args);
+				if ( $this->results ) {
+					$this->results = $this->results[$allowed_methods[$this->method]];
+
+					$this->photos = $this->results['photo'];
+					$this->total = $this->results['total'];
+					$this->pages = $this->results['pages'];
+					return true;
+				} else {
+					return false;
+				}
+			}
+		}
+
+		function get($page = null) {
+			if ( is_null($page) ) {
+				$page = $this->page;
+			} else {
+				$this->page = $page;
+			}
+			if ( $this->load($page) ) {
+				return $this->photos;
+			}
+			$this->total = 0;
+			$this->pages = 0;
+			return array();
+		}
+
+		function next() {
+			$this->page++;
+			if ( $this->load($this->page) ) {
+				return $this->photos;
+			}
+			$this->total = 0;
+			$this->pages = 0;
+			return array();
+		}
+
+	}
+}
 
 ?>

--- a/serendipity_event_flickr/serendipity_event_flickr.php
+++ b/serendipity_event_flickr/serendipity_event_flickr.php
@@ -25,7 +25,7 @@ class serendipity_event_flickr extends serendipity_event
         $propbag->add('stackable',     false);
         $propbag->add('license',       'GPL');
         $propbag->add('author',        'Jay Bertrand');
-        $propbag->add('version',       '0.6.1');
+        $propbag->add('version',       '1.0');
         $propbag->add('requirements',  array(
             'serendipity' => '0.9',
             'smarty'      => '2.6.7',

--- a/serendipity_event_flickr/serendipity_event_flickr.php
+++ b/serendipity_event_flickr/serendipity_event_flickr.php
@@ -49,7 +49,7 @@ class serendipity_event_flickr extends serendipity_event
                 $propbag->add('type', 'string');
                 $propbag->add('name', PLUGIN_EVENT_FLICKR_APIKEY);
                 $propbag->add('description', PLUGIN_EVENT_FLICKR_APIKEY_DESC);
-                $propbag->add('validate', '/^[0-9a-fA-F]{32}$/');
+                $propbag->add('validate', '/^[0-9a-fA-F]{32,33}$/');
                 $propbag->add('validate_error', PLUGIN_EVENT_FLICKR_APIKEY_INVALID);
                 $propbag->add('default', '');
                 break;
@@ -95,6 +95,9 @@ class serendipity_event_flickr extends serendipity_event
                         // TODO: add a message to the user ?!?
                         break;
                     }
+                    $flickr_username = $serendipity['POST']['flickr_username'] ?? '';
+                    $flickr_tags = $serendipity['POST']['flickr_tags'] ?? '';
+                    $flickr_keywords = $serendipity['POST']['flickr_keywords'] ?? '';
                 ?>
                 <?php echo PLUGIN_EVENT_FLICKR_IMPORT_BLAHBLAH; ?>
                 <script type="text/javascript">
@@ -115,7 +118,7 @@ class serendipity_event_flickr extends serendipity_event
                     d.style.display = (d.style.display != '') ? '' : 'none';
                 }
                 </script>
-                <h3><? echo PLUGIN_EVENT_FLICKR_IMPORT; ?></h3>
+                <h3><?php echo PLUGIN_EVENT_FLICKR_IMPORT; ?></h3>
                 <form action="?" method="POST" id="flickr_uploadform" enctype="multipart/form-data" onsubmit="">
                     <?php echo serendipity_setFormToken(); ?>
                     <?php // these two fields will only be used when an image has been chosen for dl ?>
@@ -127,17 +130,17 @@ class serendipity_event_flickr extends serendipity_event
                     <input type="hidden" name="serendipity[adminAction]" value="flickr" />
 
                     <input type="hidden" name="serendipity[flickr_page]" value="1" />
-                    Flickr username: <input class="input_textbox" name="serendipity[flickr_username]" value="<?php echo  (function_exists('serendipity_specialchars') ? serendipity_specialchars($serendipity['POST']['flickr_username']) : htmlspecialchars($serendipity['POST']['flickr_username'], ENT_COMPAT, LANG_CHARSET)) ?>" />
+                    Flickr username: <input class="input_textbox" name="serendipity[flickr_username]" value="<?php echo  (function_exists('serendipity_specialchars') ? serendipity_specialchars($flickr_username) : htmlspecialchars($flickr_username, ENT_COMPAT, LANG_CHARSET)) ?>" />
                     <input type="submit" value="<?php echo GO; ?>" class="serendipityPrettyButton input_button" /><br /><br />
                     <a style="border: 0pt none ; text-decoration: none;" href="#" onclick="flickr_toggleExtended(); return false"
                          title="<?php echo  TOGGLE_OPTION ?>">
                     <img border="0" src="<?php echo serendipity_getTemplateFile('img/plus.png') ?>" /> <?php echo  TOGGLE_ALL ?></a>
-                    <div id="flickr_extendedCriteria" <?php echo  (strlen($serendipity['POST']['flickr_username']) ? '':'style="display:none;"') ?>>
-                        <p><?php echo  PLUGIN_EVENT_FLICKR_TAGS ?> <input class="input_textbox" name="serendipity[flickr_tags]" value="<?php echo  (function_exists('serendipity_specialchars') ? serendipity_specialchars($serendipity['POST']['flickr_tags']) : htmlspecialchars($serendipity['POST']['flickr_tags'], ENT_COMPAT, LANG_CHARSET)) ?>" />
-                        <?php echo  PLUGIN_EVENT_FLICKR_KEYWORDS ?> <input class="input_textbox" name="serendipity[flickr_keywords]" value="<?php echo  (function_exists('serendipity_specialchars') ? serendipity_specialchars($serendipity['POST']['flickr_keywords']) : htmlspecialchars($serendipity['POST']['flickr_keywords'], ENT_COMPAT, LANG_CHARSET)) ?>" size="30" /></p>
+                    <div id="flickr_extendedCriteria" <?php echo  (strlen($flickr_username) ? '':'style="display:none;"') ?>>
+                        <p><?php echo  PLUGIN_EVENT_FLICKR_TAGS ?> <input class="input_textbox" name="serendipity[flickr_tags]" value="<?php echo  (function_exists('serendipity_specialchars') ? serendipity_specialchars($flickr_tags) : htmlspecialchars($flickr_tags, ENT_COMPAT, LANG_CHARSET)) ?>" />
+                        <?php echo  PLUGIN_EVENT_FLICKR_KEYWORDS ?> <input class="input_textbox" name="serendipity[flickr_keywords]" value="<?php echo  (function_exists('serendipity_specialchars') ? serendipity_specialchars($flickr_keywords) : htmlspecialchars($flickr_keywords, ENT_COMPAT, LANG_CHARSET)) ?>" size="30" /></p>
                         <?php echo  SORT_BY ?> <select id="flickr_sort" name="serendipity[flickr_sort]">
                         <option value=""></option>
-                        <?
+                        <?php
                             // See API for details (http://www.flickr.com/services/api/flickr.photos.search.html)
                             $flickr_goodSortOrders = array(
                                 'date-posted-asc'=>'By date of post, ascending',
@@ -150,9 +153,8 @@ class serendipity_event_flickr extends serendipity_event
                             );
 
                             // compute sort order
-                            $sortOrder = (isset($serendipity['POST']['flickr_keywords']) &&
-                                array_key_exists($serendipity['POST']['flickr_keywords'], $flickr_goodSortOrders) ?
-                                (function_exists('serendipity_specialchars') ? serendipity_specialchars($serendipity['POST']['flickr_keywords']) : htmlspecialchars($serendipity['POST']['flickr_keywords'], ENT_COMPAT, LANG_CHARSET)) : '');
+                            $sortOrder = (array_key_exists($flickr_keywords, $flickr_goodSortOrders) ?
+                                (function_exists('serendipity_specialchars') ? serendipity_specialchars($flickr_keywords) : htmlspecialchars($flickr_keywords, ENT_COMPAT, LANG_CHARSET)) : '');
 
                             // display possible options for sort order
                             foreach($flickr_goodSortOrders as $value => $description) {
@@ -166,22 +168,21 @@ class serendipity_event_flickr extends serendipity_event
                 </form>
                 <?php
                     // in the second step, we show latest photos (thumbs) for given username
-                    if ($serendipity['POST']['adminAction'] == 'flickr') {
+                    if (isset($serendipity['POST']['adminAction']) && $serendipity['POST']['adminAction'] == 'flickr') {
 
                         // make use of phpFlikr lib (http://www.phpflickr.com/)
                         require_once(dirname(__FILE__).'/phpFlickr/phpFlickr.php');
-
                         $f = new phpFlickr($this->get_config('api_key'));
 
                         $i = 0;
-                        if (!empty($serendipity['POST']['flickr_username'])) {
+                        if (!empty($flickr_username)) {
                             // Find the NSID of the username inputted via the form
-                            $nsid = $f->people_findByUsername($serendipity['POST']['flickr_username']);
+                            $nsid = $f->people_findByUsername($flickr_username);
 
                             // Get the friendly URL of the user's photos
                             $photos_url = $f->urls_getUserPhotos($nsid);
                             echo '<h4 style="margin-bottom: 0; padding-bottom: 0;">Photos of <em>';
-                            echo (function_exists('serendipity_specialchars') ? serendipity_specialchars($serendipity['POST']['flickr_username']) : htmlspecialchars($serendipity['POST']['flickr_username'], ENT_COMPAT, LANG_CHARSET)).'</em> at ';
+                            echo (function_exists('serendipity_specialchars') ? serendipity_specialchars($flickr_username) : htmlspecialchars($flickr_username, ENT_COMPAT, LANG_CHARSET)).'</em> at ';
                             echo '<a href="'.$photos_url.'" target="_blank">'.$photos_url.'</a></h4>';
 
                             // default page is number one
@@ -197,16 +198,16 @@ class serendipity_event_flickr extends serendipity_event
 
                             // make sure sort order is non empty AND valid
                             if(isset($serendipity['POST']['flickr_sort']) && strlen(trim($serendipity['POST']['flickr_sort'])) &&
-                                array_key_exists($serendipity['POST']['flickr_keywords'], $flickr_goodSortOrders))
+                                array_key_exists($flickr_keywords, $flickr_goodSortOrders))
                                 $searchCriteria['sort'] = (function_exists('serendipity_specialchars') ? serendipity_specialchars($serendipity['POST']['flickr_sort']) : htmlspecialchars($serendipity['POST']['flickr_sort'], ENT_COMPAT, LANG_CHARSET));
 
                             // TODO: clean up tags of unwanted characters (keep only [a-zA-Z0-9_-])
-                            if(isset($serendipity['POST']['flickr_tags']) && strlen(trim($serendipity['POST']['flickr_tags'])))
-                                $searchCriteria['tags'] = implode(',',explode(' ', (function_exists('serendipity_specialchars') ? serendipity_specialchars($serendipity['POST']['flickr_tags']) : htmlspecialchars($serendipity['POST']['flickr_tags'], ENT_COMPAT, LANG_CHARSET))));
+                            if(strlen(trim($flickr_tags)))
+                                $searchCriteria['tags'] = implode(',',explode(' ', (function_exists('serendipity_specialchars') ? serendipity_specialchars($flickr_tags) : htmlspecialchars($flickr_tags, ENT_COMPAT, LANG_CHARSET))));
 
                             // TODO: cleanup keywords
-                            if(isset($serendipity['POST']['flickr_keywords']) && strlen(trim($serendipity['POST']['flickr_keywords'])))
-                                $searchCriteria['text'] = (function_exists('serendipity_specialchars') ? serendipity_specialchars($serendipity['POST']['flickr_keywords']) : htmlspecialchars($serendipity['POST']['flickr_keywords'], ENT_COMPAT, LANG_CHARSET));
+                            if(strlen(trim($flickr_keywords)))
+                                $searchCriteria['text'] = (function_exists('serendipity_specialchars') ? serendipity_specialchars($flickr_keywords) : htmlspecialchars($flickr_keywords, ENT_COMPAT, LANG_CHARSET));
 
                             if(count($searchCriteria)) {
                                 // It seems the user wants an advanced search
@@ -214,7 +215,7 @@ class serendipity_event_flickr extends serendipity_event
                                 $photos = $f->photos_search($searchCriteria);
                             } else {
                                 // No extra criteria, get the user's next 12 public photos (+1 to show > next or not !)
-                                $photos = $f->people_getPublicPhotos($nsid, NULL, 13, $serendipity['POST']['flickr_page']);
+                                $photos = $f->people_getPublicPhotos($nsid, NULL, ['original_format'], 13, $serendipity['POST']['flickr_page']);
                                 // Get user's tags (if any)
                                 /*$tags = $f->tags_getListUser($nsid);
                                 if(is_array($tags['tags']['tag'])) {
@@ -224,7 +225,7 @@ class serendipity_event_flickr extends serendipity_event
                             }
 
                             // Loop through the photos and output the html
-                            foreach ($photos['photo'] as $photo) {
+                            foreach ($photos['photos']['photo'] as $photo) {
                                 echo '<a title="Add to library" href="javascript:flickr_doImport(\''.$f->buildPhotoURL($photo, 'Original').'\');" ';
                                 echo 'onclick="return confirm(\'Import this photo into the media library ?\');">';
                                 echo '<img border="0" alt="'.$photo['title'].'" src=' . $f->buildPhotoURL($photo, 'Square') . ' />';
@@ -245,7 +246,7 @@ class serendipity_event_flickr extends serendipity_event
                                 echo '<a href="javascript:flickr_showPage('.(int)($serendipity['POST']['flickr_page']-1).');">Previous</a>';
                             }
                             echo '&nbsp;&nbsp;';
-                            if (count($photos['photo']) > 12) {
+                            if (count($photos['photos']) > 12) {
                                 echo '<a href="javascript:flickr_showPage('.(int)($serendipity['POST']['flickr_page']+1).');">Next</a>';
                             }
 


### PR DESCRIPTION
serendipity_event_flickr was completely broken since it relied on HTTP_Request, which we had removed. It's the one remainder listed in https://github.com/s9y/Serendipity/issues/550, as the fix was not all that easy. 

This PR updates the bundled phpFlickr library to the latest version from https://github.com/dan-coulter/phpflickr. It applies additional patches to make the library actually work again (with PHP 8 and in general), and fixes the plugin code to work with those changes. Also contains a few fixes for warnings under PHP 8.

phpFlickr had previously been patched manually to use our HTTP_Request. The new version instead tries to use curl or sockets directly. I think that's okay, and we can simply not patch in HTTP_Request2 or serendipity_request_url, the current state should work fine.

Note that phpFlickr was abandoned, so the version used here isn't all that new. There is a new and maintained version at https://github.com/samwilson/phpflickr, but it's sadly overkill - using it would mean a lot of changes and new dependencies. Not needed for now I'd say, if phpFlickr breaks I'd recommend to rather remove phpFlickr completely and handle the limited API functionality we actually need in custom code.