### PR TITLE
staticpage 4.15.10: Reworked table creation/upgrade, smarty escape fix, PHP 8 fixes

### DIFF
--- a/serendipity_event_staticpage/ChangeLog
+++ b/serendipity_event_staticpage/ChangeLog
@@ -1,6 +1,7 @@
 4.15.10:
     * Avoid warnings under PHP 8.4
     * Fix database creation/updater function, to avoid a recurrent install error
+    * Fix entry editor markup buttons not having any effect
     
 4.15.9:
     * Avoid warnings under PHP 8.2

--- a/serendipity_event_staticpage/ChangeLog
+++ b/serendipity_event_staticpage/ChangeLog
@@ -1,3 +1,7 @@
+4.15.10:
+    * Avoid warnings under PHP 8.4
+    * Fix database creation/updater function, to avoid a recurrent install error
+    
 4.15.9:
     * Avoid warnings under PHP 8.2
     

--- a/serendipity_event_staticpage/backend_templates/default_staticpage_backend.tpl
+++ b/serendipity_event_staticpage/backend_templates/default_staticpage_backend.tpl
@@ -3,22 +3,22 @@
         <h4>{$CONST.STATICPAGE_SECTION_BASIC}</h4>
 
         <div class="form_field">
-            <label title="{staticpage_input item="headline" what="desc"|escape:js}">{staticpage_input item="headline" what="name"|escape:js}</label>
+            <label title="{staticpage_input item="headline" what="desc"|escape:javascript}">{staticpage_input item="headline" what="name"|escape:javascript}</label>
             {staticpage_input item="headline"}
         </div>
 
         <div class="form_field">
-            <label title="{staticpage_input item="articleformattitle" what="desc"|escape:js}">{staticpage_input item="articleformattitle" what="name"|escape:js}</label>
+            <label title="{staticpage_input item="articleformattitle" what="desc"|escape:javascript}">{staticpage_input item="articleformattitle" what="name"|escape:javascript}</label>
             {staticpage_input item="articleformattitle"}
         </div>
 
         <div class="form_field">
-            <label title="{staticpage_input item="content" what="desc"|escape:js}">{staticpage_input item="content" what="name"|escape:js}</label>
+            <label title="{staticpage_input item="content" what="desc"|escape:javascript}">{staticpage_input item="content" what="name"|escape:javascript}</label>
             {staticpage_input item="content"}
         </div>
 
         <div class="form_field">
-            <label title="{staticpage_input item="pre_content" what="desc"|escape:js}">{staticpage_input item="pre_content" what="name"|escape:js}</label>
+            <label title="{staticpage_input item="pre_content" what="desc"|escape:javascript}">{staticpage_input item="pre_content" what="name"|escape:javascript}</label>
             {staticpage_input item="pre_content"}
         </div>
     </section>
@@ -33,32 +33,32 @@
                 <h4>{$CONST.STATICPAGE_SECTION_STRUCT}</h4>
 
                 <div class="form_field">
-                    <label title="{staticpage_input item="pagetitle" what="desc"|escape:js}">{staticpage_input item="pagetitle" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="pagetitle" what="desc"|escape:javascript}">{staticpage_input item="pagetitle" what="name"|escape:javascript}</label>
                     {staticpage_input item="pagetitle"}
                 </div>
 
                 <div class="form_field">
-                    <label title="{staticpage_input item="permalink" what="desc"|escape:js}">{staticpage_input item="permalink" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="permalink" what="desc"|escape:javascript}">{staticpage_input item="permalink" what="name"|escape:javascript}</label>
                     {staticpage_input item="permalink"}
                 </div>
 
                 <div class="form_select">
-                    <label title="{staticpage_input item="publishstatus" what="desc"|escape:js}">{staticpage_input item="publishstatus" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="publishstatus" what="desc"|escape:javascript}">{staticpage_input item="publishstatus" what="name"|escape:javascript}</label>
                     {staticpage_input item="publishstatus"}
                 </div>
 
                 <div class="form_select">
-                    <label title="{staticpage_input item="articletype" what="desc"|escape:js}">{staticpage_input item="articletype" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="articletype" what="desc"|escape:javascript}">{staticpage_input item="articletype" what="name"|escape:javascript}</label>
                     {staticpage_input item="articletype"}
                 </div>
 
                 <div class="form_select">
-                    <label title="{staticpage_input item="language" what="desc"|escape:js}">{staticpage_input item="language" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="language" what="desc"|escape:javascript}">{staticpage_input item="language" what="name"|escape:javascript}</label>
                     {staticpage_input item="language"}
                 </div>
 
                 <div class="form_select">
-                    <label title="{staticpage_input item="related_category_id" what="desc"|escape:js}">{staticpage_input item="related_category_id" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="related_category_id" what="desc"|escape:javascript}">{staticpage_input item="related_category_id" what="name"|escape:javascript}</label>
                     {staticpage_input item="related_category_id"}
                 </div>
             </div>
@@ -69,32 +69,32 @@
                 <h4>{$CONST.STATICPAGE_SECTION_ACCESS}</h4>
 
                 <div class="form_field">
-                    <label title="{staticpage_input item="pass" what="desc"|escape:js}">{staticpage_input item="pass" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="pass" what="desc"|escape:javascript}">{staticpage_input item="pass" what="name"|escape:javascript}</label>
                     {staticpage_input item="pass"}
                 </div>
 
                 <div class="form_select">
-                    <label title="{staticpage_input item="parent_id" what="desc"|escape:js}">{staticpage_input item="parent_id" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="parent_id" what="desc"|escape:javascript}">{staticpage_input item="parent_id" what="name"|escape:javascript}</label>
                     {staticpage_input item="parent_id"}
                 </div>
 
                 <fieldset class="clearfix">
-                    <span class="wrap_legend"><legend title="{staticpage_input item="show_childpages" what="desc"|escape:js}">{staticpage_input item="show_childpages" what="name"|escape:js}</legend></span>
+                    <span class="wrap_legend"><legend title="{staticpage_input item="show_childpages" what="desc"|escape:javascript}">{staticpage_input item="show_childpages" what="name"|escape:javascript}</legend></span>
                     {staticpage_input item="show_childpages"}
                 </fieldset>
 
                 <fieldset class="clearfix">
-                    <span class="wrap_legend"><legend title="{staticpage_input item="shownavi" what="desc"|escape:js}">{staticpage_input item="shownavi" what="name"|escape:js}</legend></span>
+                    <span class="wrap_legend"><legend title="{staticpage_input item="shownavi" what="desc"|escape:javascript}">{staticpage_input item="shownavi" what="name"|escape:javascript}</legend></span>
                     {staticpage_input item="shownavi"}
                 </fieldset>
 
                 <fieldset class="clearfix">
-                    <span class="wrap_legend"><legend title="{staticpage_input item="showonnavi" what="desc"|escape:js}">{staticpage_input item="showonnavi" what="name"|escape:js}</legend></span>
+                    <span class="wrap_legend"><legend title="{staticpage_input item="showonnavi" what="desc"|escape:javascript}">{staticpage_input item="showonnavi" what="name"|escape:javascript}</legend></span>
                     {staticpage_input item="showonnavi"}
                 </fieldset>
 
                 <fieldset class="clearfix">
-                    <span class="wrap_legend"><legend title="{staticpage_input item="show_breadcrumb" what="desc"|escape:js}">{staticpage_input item="show_breadcrumb" what="name"|escape:js}</legend></span>
+                    <span class="wrap_legend"><legend title="{staticpage_input item="show_breadcrumb" what="desc"|escape:javascript}">{staticpage_input item="show_breadcrumb" what="name"|escape:javascript}</legend></span>
                     {staticpage_input item="show_breadcrumb"}
                 </fieldset>
             </div>
@@ -105,27 +105,27 @@
                 <h4>{$CONST.STATICPAGE_SECTION_META}</h4>
 
                 <div class="form_field">
-                    <label title="{staticpage_input item="timestamp" what="desc"|escape:js}">{staticpage_input item="timestamp" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="timestamp" what="desc"|escape:javascript}">{staticpage_input item="timestamp" what="name"|escape:javascript}</label>
                     {staticpage_input item="timestamp"}
                 </div>
 
                 <div class="form_select">
-                    <label title="{staticpage_input item="authorid" what="desc"|escape:js}">{staticpage_input item="authorid" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="authorid" what="desc"|escape:javascript}">{staticpage_input item="authorid" what="name"|escape:javascript}</label>
                     {staticpage_input item="authorid"}
                 </div>
 
                 <div class="form_field">
-                    <label title="{staticpage_input item="title_element" what="desc"|escape:js}">{staticpage_input item="title_element" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="title_element" what="desc"|escape:javascript}">{staticpage_input item="title_element" what="name"|escape:javascript}</label>
                     {staticpage_input item="title_element"}
                 </div>
 
                 <div class="form_field">
-                    <label title="{staticpage_input item="meta_description" what="desc"|escape:js}">{staticpage_input item="meta_description" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="meta_description" what="desc"|escape:javascript}">{staticpage_input item="meta_description" what="name"|escape:javascript}</label>
                     {staticpage_input item="meta_description"}
                 </div>
 
                 <div class="form_field">
-                    <label title="{staticpage_input item="meta_keywords" what="desc"|escape:js}">{staticpage_input item="meta_keywords" what="name"|escape:js}</label>
+                    <label title="{staticpage_input item="meta_keywords" what="desc"|escape:javascript}">{staticpage_input item="meta_keywords" what="name"|escape:javascript}</label>
                     {staticpage_input item="meta_keywords"}
                 </div>
             </div>
@@ -136,22 +136,22 @@
                 <h4>{$CONST.STATICPAGE_SECTION_OPT}</h4>
 
                 <fieldset class="clearfix">
-                    <span class="wrap_legend"><legend title="{staticpage_input item="is_startpage" what="desc"|escape:js}">{staticpage_input item="is_startpage" what="name"|escape:js}</legend></span>
+                    <span class="wrap_legend"><legend title="{staticpage_input item="is_startpage" what="desc"|escape:javascript}">{staticpage_input item="is_startpage" what="name"|escape:javascript}</legend></span>
                     {staticpage_input item="is_startpage"}
                 </fieldset>
 
                 <fieldset class="clearfix">
-                    <span class="wrap_legend"><legend title="{staticpage_input item="is_404_page" what="desc"|escape:js}">{staticpage_input item="is_404_page" what="name"|escape:js}</legend></span>
+                    <span class="wrap_legend"><legend title="{staticpage_input item="is_404_page" what="desc"|escape:javascript}">{staticpage_input item="is_404_page" what="name"|escape:javascript}</legend></span>
                     {staticpage_input item="is_404_page"}
                 </fieldset>
 
                 <fieldset class="clearfix">
-                    <span class="wrap_legend"><legend title="{staticpage_input item="markup" what="desc"|escape:js}">{staticpage_input item="markup" what="name"|escape:js}</legend></span>
+                    <span class="wrap_legend"><legend title="{staticpage_input item="markup" what="desc"|escape:javascript}">{staticpage_input item="markup" what="name"|escape:javascript}</legend></span>
                     {staticpage_input item="markup"}
                 </fieldset>
 
                 <fieldset class="clearfix">
-                    <span class="wrap_legend"><legend title="{staticpage_input item="articleformat" what="desc"|escape:js}">{staticpage_input item="articleformat" what="name"|escape:js}</legend></span>
+                    <span class="wrap_legend"><legend title="{staticpage_input item="articleformat" what="desc"|escape:javascript}">{staticpage_input item="articleformat" what="name"|escape:javascript}</legend></span>
                     {staticpage_input item="articleformat"}
                 </fieldset>
             </div>

--- a/serendipity_event_staticpage/serendipity_event_staticpage.php
+++ b/serendipity_event_staticpage/serendipity_event_staticpage.php
@@ -788,7 +788,8 @@ class serendipity_event_staticpage extends serendipity_event
 
         $built = $this->get_config('db_built', null);
         if (empty($built) || $built == null) {
-            // We likely can create a full complete table from scratch
+            // We create the original minimal table here. The upgrade steps below
+            // will upgrade it to the full table setup the plugin needs,
             serendipity_db_schema_import("CREATE TABLE IF NOT EXISTS {$serendipity['dbPrefix']}staticpages (
                     id {AUTOINCREMENT} {PRIMARY},
                     articleformattitle varchar(255) not null default '',
@@ -962,7 +963,7 @@ class serendipity_event_staticpage extends serendipity_event
         $this->set_config('db_built', 21);
     }
 
-    // Return true if the plugin database already has the given column. Helper for the setupDB
+    // Return true if the plugin database table already has the given column. Helper for the setupDB
     // function.
     function has_column($column) {
         global $serendipity;

--- a/serendipity_event_staticpage/serendipity_event_staticpage.php
+++ b/serendipity_event_staticpage/serendipity_event_staticpage.php
@@ -786,89 +786,65 @@ class serendipity_event_staticpage extends serendipity_event
         global $serendipity;
 
         $built = $this->get_config('db_built', null);
-        $fresh = false;
-        if ((empty($built)) && (!defined('STATICPAGE_UPGRADE_DONE'))) {
+        if (empty($built) || $built == null) {
+            // We likely can create a full complete table from scratch
             serendipity_db_schema_import("CREATE TABLE IF NOT EXISTS {$serendipity['dbPrefix']}staticpages (
                     id {AUTOINCREMENT} {PRIMARY},
-                    parent_id int(11) default '0',
                     articleformattitle varchar(255) not null default '',
                     articleformat int(1) default '1',
                     markup int(1) default '1',
                     pagetitle varchar(255) not null default '',
                     permalink varchar(255) not null default '',
-                    is_startpage int(1) default '0',
-                    is_404_page int(1) default '0',
-                    show_childpages int(1) not null default '0',
                     content text,
-                    pre_content text,
                     headline varchar(255) not null default '',
                     filename varchar(255) not null default '',
-                    pass varchar(255) not null default '',
                     timestamp int(10) {UNSIGNED} default null,
-                    last_modified int(10) {UNSIGNED} default null,
-                    authorid int(11) default '0',
-                    pageorder int(4) default '0',
-                    articletype int(4) default '0',
-                    related_category_id int(4) default 0,
-                    shownavi int(4) default '1',
-                    showonnavi int(4) default '1',
-                    show_breadcrumb int(4) default '1',
-                    publishstatus int(4) default '1',
-                    language varchar(10) default '') {UTF_8}");
+                    authorid int(11) default '0'
+                    ) {UTF_8}");
 
-            $old_stuff = serendipity_db_query("SELECT * FROM {$serendipity['dbPrefix']}config WHERE name LIKE 'serendipity_event_staticpage:%'");
-
-            $import = array();
-            if (is_array($old_stuff)) {
-                foreach ($old_stuff as $item) {
-                    $names = explode('/', $item['name']);
-                    if (!isset($import[$names[0]])) {
-                        $import[$names[0]] = array('authorid' => $item['authorid']);
-                    }
-
-                    $import[$names[0]][$names[1]] = serendipity_get_bool($item['value']);
-                }
-            }
-
-            foreach ($import AS $page) {
-                if (is_array($page)) {
-                    try {
-                        serendipity_db_insert('staticpages', $page);
-                        @unlink($this->cachefile);
-                    } catch (Exception $e) {
-                        // one part of the setup did not work, which is probably not bad.
-                    }
-                }
-            }
-
-            serendipity_db_query("DELETE FROM {$serendipity['dbPrefix']}config  WHERE name LIKE 'serendipity_event_staticpage:%'");
-            serendipity_db_query("DELETE FROM {$serendipity['dbPrefix']}plugins WHERE name LIKE 'serendipity_event_staticpage:%' AND name NOT LIKE '" . serendipity_db_escape_string($this->instance) . "'");
-            $this->set_config('db_built', '7');
-            $fresh = true;
-            @define('STATICPAGE_UPGRADE_DONE', true); // No further static pages may be called!
+            $this->set_config('db_built', '0');
         }
 
         switch ($built) {
+            case 0:
             case 1: // password not included
-                $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN pass varchar(255) not null default ''";
-                serendipity_db_schema_import($q);
+                if (!$this->has_column('pass')) {
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN pass varchar(255) not null default ''";
+                    serendipity_db_schema_import($q);
+                }
+                $this->set_config('db_built', 1);
             case 2: // parent-id not included
-                $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN parent_id int(11) default '0'";
-                serendipity_db_schema_import($q);
+                if (!$this->has_column('parent_id')) {
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN parent_id int(11) default '0'";
+                    serendipity_db_schema_import($q);
+                }
+                $this->set_config('db_built', 2);
             case 3:
-                $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN show_childpages int(1) not null default '0'";
-                serendipity_db_schema_import($q); // list of child-pages on parent-page
-                $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN pre_content text";
-                serendipity_db_schema_import($q); // content
+                if (!$this->has_column('show_childpages')) {
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN show_childpages int(1) not null default '0'";
+                    serendipity_db_schema_import($q); // list of child-pages on parent-page
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN pre_content text";
+                    serendipity_db_schema_import($q); // content
+                }
+                $this->set_config('db_built', 3);
             case 4:
-                $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN is_startpage int(1) default '0'";
-                serendipity_db_schema_import($q);
+                if (!$this->has_column('is_startpage')) {
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN is_startpage int(1) default '0'";
+                    serendipity_db_schema_import($q);
+                }
+                $this->set_config('db_built', 4);
             case 5: // enum to re-order staticpages
-                $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN pageorder int(4) default '0'";
-                serendipity_db_schema_import($q);
+                if (!$this->has_column('pageorder')) {
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN pageorder int(4) default '0'";
+                    serendipity_db_schema_import($q);
+                }
+                $this->set_config('db_built', 5);
             case 6:
-                $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN articletype int(4) default '0'";
-                serendipity_db_schema_import($q);
+                if (!$this->has_column('articletype')) {
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN articletype int(4) default '0'";
+                    serendipity_db_schema_import($q);
+                }
+                $this->set_config('db_built', 6);
             case 7:
                 $q = "CREATE TABLE IF NOT EXISTS {$serendipity['dbPrefix']}staticpages_types (
                         id {AUTOINCREMENT} {PRIMARY},
@@ -895,44 +871,44 @@ class serendipity_event_staticpage extends serendipity_event
                     serendipity_db_update('staticpages', array(), $set);
                     @unlink($this->cachefile);
                 }
+                $this->set_config('db_built', 7);
             case 8:
             case 9:
             case 10:
-                if (!$fresh) {
-                    if ($serendipity['dbType'] != 'sqlite' && $serendipity['dbType'] != 'sqlite3' && $serendipity['dbType'] != 'pdo-sqlite') {
-                        $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN shownavi int(4) default '1';";
-                        serendipity_db_schema_import($q);
-                        $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN showonnavi int(4) default '1'";
-                        serendipity_db_schema_import($q);
-                        $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN publishstatus int(4) default '1';";
-                        serendipity_db_schema_import($q);
-                        $q = 'ALTER TABLE '.$serendipity['dbPrefix'].'staticpages ADD COLUMN language varchar(10) default \'\'';
-                        serendipity_db_schema_import($q);
-                    }
-                    $q = 'DROP TABLE IF EXISTS '.$serendipity['dbPrefix'].'staticpages_plugins';
+                if (!$this->has_column('shownavi')) {
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN shownavi int(4) default '1';";
+                    serendipity_db_schema_import($q);
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN showonnavi int(4) default '1'";
+                    serendipity_db_schema_import($q);
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN publishstatus int(4) default '1';";
+                    serendipity_db_schema_import($q);
+                    $q = 'ALTER TABLE '.$serendipity['dbPrefix'].'staticpages ADD COLUMN language varchar(10) default \'\'';
                     serendipity_db_schema_import($q);
                 }
+                $q = 'DROP TABLE IF EXISTS '.$serendipity['dbPrefix'].'staticpages_plugins';
+                serendipity_db_schema_import($q);
+                $this->set_config('db_built', 10);
             case 11:
                 serendipity_db_update('staticpages_types', array('description' => 'Aboutpage'), array('description' => 'Overview'));
+                $this->set_config('db_built', 11);
             case 12:
-                $q = "CREATE {FULLTEXT_MYSQL} INDEX staticentry_idx on {$serendipity['dbPrefix']}staticpages (headline, content);";
+                $q = "CREATE {FULLTEXT_MYSQL} INDEX IF NOT EXISTS staticentry_idx on {$serendipity['dbPrefix']}staticpages (headline, content);";
                 serendipity_db_schema_import($q);
+                $this->set_config('db_built', 12);
             case 13:
             case 14:
-                if (!$fresh) {
-                    if ($serendipity['dbType'] != 'sqlite' && $serendipity['dbType'] != 'sqlite3' && $serendipity['dbType'] != 'pdo-sqlite') {
-                        $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN last_modified int(10)";
-                        serendipity_db_schema_import($q);
-                        serendipity_db_query("UPDATE {$serendipity['dbPrefix']}staticpages SET last_modified = timestamp");
-                    }
+                if (!$this->has_column('last_modified')) {
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN last_modified int(10)";
+                    serendipity_db_schema_import($q);
+                    serendipity_db_query("UPDATE {$serendipity['dbPrefix']}staticpages SET last_modified = timestamp");
                 }
+                $this->set_config('db_built', 14);
             case 15:
-                if (!$fresh) {
-                    if ($serendipity['dbType'] != 'sqlite' && $serendipity['dbType'] != 'sqlite3' && $serendipity['dbType'] != 'pdo-sqlite') {
-                        $sql = 'ALTER TABLE '.$serendipity['dbPrefix'].'staticpages ADD COLUMN related_category_id int(4) default 0';
-                        serendipity_db_schema_import($sql);
-                    }
+                if (!$this->has_column('related_category_id')) {
+                    $sql = 'ALTER TABLE '.$serendipity['dbPrefix'].'staticpages ADD COLUMN related_category_id int(4) default 0';
+                    serendipity_db_schema_import($sql);
                 }
+                $this->set_config('db_built', 15);
             case 16:
                 $this->pagetype = array(
                     'description' => 'Staticpage with related category',
@@ -945,6 +921,7 @@ class serendipity_event_staticpage extends serendipity_event
                             staticpage_categorypage int(4) default 0
                         ) {UTF_8}';
                 serendipity_db_schema_import($sql);
+                $this->set_config('db_built', 16);
             case 17:
                 $sql = 'CREATE TABLE IF NOT EXISTS '.$serendipity['dbPrefix'].'staticpage_custom (
                             staticpage int(11),
@@ -952,23 +929,24 @@ class serendipity_event_staticpage extends serendipity_event
                             value text
                         ) {UTF_8}';
                 serendipity_db_schema_import($sql);
+                $this->set_config('db_built', 17);
             case 18:
-                    if ($serendipity['dbType'] != 'sqlite' && $serendipity['dbType'] != 'sqlite3' && $serendipity['dbType'] != 'pdo-sqlite') {
-                        $sql = 'ALTER TABLE '.$serendipity['dbPrefix'].'staticpages ADD COLUMN is_404_page int(1) default 0';
-                        if ($serendipity['dbType'] == 'mysql' || $serendipity['dbType'] == 'mysqli') {
-                            $sql .= ' AFTER is_startpage';
-                        }
-                        serendipity_db_schema_import($sql);
+                if (!$this->has_column('is_404_page')) {
+                    $sql = 'ALTER TABLE '.$serendipity['dbPrefix'].'staticpages ADD COLUMN is_404_page int(1) default 0';
+                    if ($serendipity['dbType'] == 'mysql' || $serendipity['dbType'] == 'mysqli') {
+                        $sql .= ' AFTER is_startpage';
                     }
-            case 19:
-                if (!$fresh) {
-                    if ($serendipity['dbType'] != 'sqlite' && $serendipity['dbType'] != 'sqlite3' && $serendipity['dbType'] != 'pdo-sqlite') {
-                        $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN show_breadcrumb int(4) default '1'";
-                        serendipity_db_schema_import($q);
-                    }
+                    serendipity_db_schema_import($sql);
                 }
+                $this->set_config('db_built', 18);
+            case 19:
+                if (!$this->has_column('show_breadcrumb')) {
+                    $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN show_breadcrumb int(4) default '1'";
+                    serendipity_db_schema_import($q);
+                }
+                $this->set_config('db_built', 19);
             case 20:
-                if (!$fresh) {
+                if (!$this->has_column('title_element')) {
                     $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN title_element varchar(255) not null default ''";
                     serendipity_db_schema_import($q);
                     $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN meta_description varchar(255) not null default ''";
@@ -976,11 +954,32 @@ class serendipity_event_staticpage extends serendipity_event
                     $q = "ALTER TABLE {$serendipity['dbPrefix']}staticpages ADD COLUMN meta_keywords varchar(255) not null default ''";
                     serendipity_db_schema_import($q);
                 }
-                $this->set_config('db_built', 21);
+                
+                $this->set_config('db_built', 20);
                 break;
         }
+        $this->set_config('db_built', 21);
     }
 
+    // Return true if the plugin database already has the given column. Helper for the setupDB
+    // function.
+    function has_column($column) {
+        global $serendipity;
+         if ($serendipity['dbType'] == 'postgres') {
+            $q = "SELECT COUNT(*) FROM information_schema.columns 
+                WHERE table_name='{$serendipity['dbPrefix']}staticpages' and column_name='$column'";
+        } elseif ($serendipity['dbType'] == 'sqlite' || $serendipity['dbType'] == 'sqlite3' || $serendipity['dbType'] == 'pdo-sqlite') {
+            $q = "SELECT COUNT(*) FROM pragma_table_info('{$serendipity['dbPrefix']}staticpages')
+                  WHERE name='$column'";
+        } else {
+            // mysql
+            $q = "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE
+                  TABLE_NAME = '{$serendipity['dbPrefix']}staticpages' AND COLUMN_NAME = '$column'";
+        }
+        $result = serendipity_db_query($q, true);
+        return ($result[0] > 0);
+    }
 
     /**
      *

--- a/serendipity_event_staticpage/serendipity_event_staticpage.php
+++ b/serendipity_event_staticpage/serendipity_event_staticpage.php
@@ -2340,13 +2340,12 @@ foreach($select AS $select_value => $select_desc) {
                     if (!$serendipity['wysiwyg']) {
 ?>                  <nobr><span id="tools_<?php echo $config_item ?>" style="display: none">
                         <?php if( $serendipity['nl2br']['iso2br'] ) { ?>
-                        <input type="button" class="serendipityPrettyButton input_button" name="insX" value="NoBR" accesskey="x" style="font-style: italic" onclick="wrapSelection(document.forms['serendipityEntry']['serendipity[plugin][<?php echo $config_item ?>]'],'<nl>','</nl>')" />
+                        <input type="button" class="serendipityPrettyButton input_button" name="insX" value="NoBR" accesskey="x" style="font-style: italic" onclick="serendipity.wrapSelection(document.forms['serendipityEntry']['serendipity[plugin][<?php echo $config_item ?>]'],'<nl>','</nl>')" />
                         <?php } ?>
-                        <input type="button" class="serendipityPrettyButton input_button wrap_selection" name="insI" value="I" accesskey="i" data-tarea="nuggets<?php echo $elcount; ?>" data-tag="em" style="font-style: italic" onclick="wrapSelection(document.forms['serendipityEntry']['serendipity[plugin][<?php echo $config_item ?>]'],'<em>','</em>')" />
-                        <input type="button" class="serendipityPrettyButton input_button wrap_selection" name="insB" value="B" accesskey="b" data-tarea="nuggets<?php echo $elcount; ?>" data-tag="strong" style="font-weight: bold" onclick="wrapSelection(document.forms['serendipityEntry']['serendipity[plugin][<?php echo $config_item ?>]'],'<strong>','</strong>')" />
-                        <input type="button" class="serendipityPrettyButton input_button wrap_selection" name="insU" value="U" accesskey="u" data-tarea="nuggets<?php echo $elcount; ?>" data-tag="u" style="text-decoration: underline;" onclick="wrapSelection(document.forms['serendipityEntry']['serendipity[plugin][<?php echo $config_item ?>]'],'<u>','</u>')" />
-                        <input type="button" class="serendipityPrettyButton input_button wrap_selection" name="insQ" value="<?php echo QUOTE ?>" accesskey="q" data-tarea="nuggets<?php echo $elcount; ?>" data-tag="blockquote" style="font-style: italic" onclick="wrapSelection(document.forms['serendipityEntry']['serendipity[plugin][<?php echo $config_item ?>]'],'<blockquote>','</blockquote>')" />
-                        <input type="button" class="serendipityPrettyButton input_button wrap_insimg" name="insJ" value="img" accesskey="j" data-tarea="nuggets<?php echo $elcount; ?>" onclick="wrapInsImage(document.forms['serendipityEntry']['serendipity[plugin][<?php echo $config_item ?>]'])" />
+                        <input type="button" class="serendipityPrettyButton input_button wrap_selection lang-html" name="insI" value="I" accesskey="i" data-tarea="nuggets<?php echo $elcount; ?>" data-tag-open="em" data-tag-close="em" style="font-style: italic" />
+                        <input type="button" class="serendipityPrettyButton input_button wrap_selection lang-html" name="insB" value="B" accesskey="b" data-tarea="nuggets<?php echo $elcount; ?>" data-tag-open="strong" data-tag-close="strong" style="font-weight: bold" />
+                        <input type="button" class="serendipityPrettyButton input_button wrap_selection lang-html " name="insQ" value="<?php echo QUOTE ?>" accesskey="q" data-tarea="nuggets<?php echo $elcount; ?>" data-tag-open="blockquote" data-tag-close="blockquote" />
+                        <input type="button" class="serendipityPrettyButton input_button wrap_insimg" name="insJ" value="img" accesskey="j" data-tarea="nuggets<?php echo $elcount; ?>" onclick="serendipity.wrapInsImage(document.forms['serendipityEntry']['serendipity[plugin][<?php echo $config_item ?>]'])" />
                         <?php
                         if (version_compare(serendipity_getCoreVersion($serendipity['version']), "2.0", ">=")) {
                             ?>
@@ -2358,7 +2357,7 @@ foreach($select AS $select_value => $select_desc) {
                             <?php
                         }
                         ?>
-                        <input type="button" class="serendipityPrettyButton input_button wrap_insurl" name="insU" value="URL" accesskey="l" data-tarea="nuggets<?php echo $elcount; ?>" style="color: blue; text-decoration: underline;" onclick="wrapSelectionWithLink(document.forms['serendipityEntry']['serendipity[plugin][<?php echo $config_item ?>]'])" />
+                        <input type="button" class="serendipityPrettyButton input_button wrap_insurl" name="insU" value="URL" accesskey="l" data-tarea="nuggets<?php echo $elcount; ?>" />
                     </span></nobr>
 <?php               } ?>
                     <script type="text/javascript" language="JavaScript">

--- a/serendipity_event_staticpage/serendipity_event_staticpage.php
+++ b/serendipity_event_staticpage/serendipity_event_staticpage.php
@@ -17,6 +17,7 @@ class serendipity_event_staticpage extends serendipity_event
     var $error_404 = FALSE;
     var $cachefile;
     var $smarty_init = false;
+    var $htmlnugget = [];
 
     var $config = array(
             'headline',

--- a/serendipity_event_staticpage/serendipity_event_staticpage.php
+++ b/serendipity_event_staticpage/serendipity_event_staticpage.php
@@ -87,7 +87,7 @@ class serendipity_event_staticpage extends serendipity_event
         $propbag->add('page_configuration', $this->config);
         $propbag->add('type_configuration', $this->config_types);
         $propbag->add('author', 'Marco Rinck, Garvin Hicking, David Rolston, Falk Doering, Stephan Manske, Pascal Uhlmann, Ian, Don Chambers');
-        $propbag->add('version', '4.15.9');
+        $propbag->add('version', '4.15.10');
         $propbag->add('requirements',  array(
             'serendipity' => '2.0',
             'smarty'      => '2.6.7',


### PR DESCRIPTION
The staticpage plugin was always throwing an error on installation. The error did not block the plugin from working, on a reload the database was fully created, but the logic of how upgrades and fresh installs works was broken. This fixes the error by only creating a minimal table and upgrading it with the same alter statements that an old plugin installation would go through.

Also fixes the upgrade process when using sqlite. Sqlite can add columns since 2005, but it was blocked here from doing so without providing an alternative. I removed the checks for the db type.

Plus some fixes for PHP 8 warnings and the smarty escape error reported in https://github.com/s9y/Serendipity/issues/863.