### PR TITLE
guestbook 3.61.3: Fixes for PHP 8 warnings

### DIFF
--- a/serendipity_event_guestbook/ChangeLog
+++ b/serendipity_event_guestbook/ChangeLog
@@ -1,3 +1,9 @@
+3.61.3 & 1.26.3:
+-----
+ * Address multiple PHP 8 compatibility warnings
+ * Remove bundled specialchar wrapper, use core function instead
+ * Remove bundles email validation function, use filter_var instead
+ 
 3.61.2 & 1.26.2: Hotfixes for PHP 8 (surrim)
 
 3.61.1 & 1.26.1: Translation fixes (German).

--- a/serendipity_event_guestbook/serendipity_event_guestbook.php
+++ b/serendipity_event_guestbook/serendipity_event_guestbook.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * serendipity_event_guestbook.php, v.3.57 - 2015-08-20
- */
-
-//error_reporting(E_ALL);
-
 if (IN_serendipity !== true) {
     die ("Don't hack!");
 }
@@ -448,30 +442,6 @@ class serendipity_event_guestbook extends serendipity_event {
 
 
     /**
-     * guestbook wrapper for htmlspecialchars charset switch with PHP 5.4
-     *
-     * @access public
-     * @return string
-     */
-    public static function html_specialchars($string, $flags = null, $encoding = LANG_CHARSET, $double_encode = true) {
-        if ($flags == null) {
-            if (defined('ENT_HTML401')) {
-                // Added with PHP 5.4.x
-                $flags = ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE;
-            } else {
-                // For PHP < 5.4 compatibility
-                $flags = ENT_COMPAT;
-            }
-        }
-        if ($encoding == 'LANG_CHARSET') {
-            $encoding = 'UTF-8'; // fallback
-        }
-
-        return htmlspecialchars($string, $flags, $encoding, $double_encode);
-    }
-
-
-    /**
      * Strip and secure $serendipity['POST'] by keys and define modified array var if value has changed
      * No need for trim(strip_tags()) here, while this changes length and is further on done on output separately!
      *
@@ -484,12 +454,12 @@ class serendipity_event_guestbook extends serendipity_event {
     function strip_security($parr = null, $keys = null, $single = false, $compare = true) {
         $authenticated_user = serendipity_userLoggedIn() ? true : false;
         if ($single) {
-            return $authenticated_user ? $this->html_specialchars($parr) : $this->html_specialchars(strip_tags($parr));
+            return $authenticated_user ? serendipity_specialchars($parr) : serendipity_specialchars(strip_tags($parr));
         } else { // POST data input check
             foreach ($parr AS $k => $v) {
                 if (in_array($k, $keys)) {
                     $valuelength = strlen($v);
-                    #$parrsec[$k] = $authenticated_user ? $this->html_specialchars($v) : $this->html_specialchars(strip_tags($v));//dont store entities
+                    #$parrsec[$k] = $authenticated_user ? serendipity_specialchars($v) : serendipity_specialchars(strip_tags($v));//dont store entities
                     $parrsec[$k] = $authenticated_user ? $v : strip_tags($v);
                     if (!$authenticated_user && $compare && ($valuelength != strlen($parrsec[$k]))) {
                         $parrsec['stripped'] = true;
@@ -655,7 +625,7 @@ class serendipity_event_guestbook extends serendipity_event {
                     $entry['body']      = nl2br($entry['bodywrap']);
                 }
                 if ($backend_escape) {
-                    $replace_ac = $this->html_specialchars($replace_ac); // do not allow in backend, eg unescaped scripts
+                    $replace_ac = serendipity_specialchars($replace_ac); // do not allow in backend, eg unescaped scripts
                 }
                 $entry['body']          = str_replace($placeholder_ac, $replace_ac, $entry['body']);
                 $entry['body']          = $this->text_pattern_bbc($entry['body']);
@@ -886,7 +856,7 @@ class serendipity_event_guestbook extends serendipity_event {
 
             if (isset($serendipity['POST']['email']) && !empty($serendipity['POST']['email']) && trim($serendipity['POST']['email']) != '') {
                 if (!$this->is_valid_email($serendipity['POST']['email'])) {
-                    array_push($messages, ERROR_NOVALIDEMAIL . ' <span class="gb_msgred">' . $this->html_specialchars($serendipity['POST']['email']) . '</span>');
+                    array_push($messages, ERROR_NOVALIDEMAIL . ' <span class="gb_msgred">' . serendipity_specialchars($serendipity['POST']['email']) . '</span>');
                 } else {
                     $valid['data_email'] = TRUE;
                 }
@@ -1117,12 +1087,12 @@ class serendipity_event_guestbook extends serendipity_event {
                     'plugin_guestbook_intro'           => $this->get_config('intro'),
                     'plugin_guestbook_sent'            => $this->get_config('sent', PLUGIN_GUESTBOOK_SENT_HTML),
                     'plugin_guestbook_action'          => $serendipity['baseURL'] . $serendipity['indexFile'],
-                    'plugin_guestbook_sname'           => $this->html_specialchars($serendipity['GET']['subpage']),
-                    'plugin_guestbook_name'            => $this->html_specialchars(strip_tags($serendipity['POST']['name'])),
-                    'plugin_guestbook_email'           => $this->html_specialchars(strip_tags($serendipity['POST']['email'])),
+                    'plugin_guestbook_sname'           => serendipity_specialchars($serendipity['GET']['subpage']),
+                    'plugin_guestbook_name'            => serendipity_specialchars(strip_tags($serendipity['POST']['name'])),
+                    'plugin_guestbook_email'           => serendipity_specialchars(strip_tags($serendipity['POST']['email'])),
                     'plugin_guestbook_emailprotect'    => PLUGIN_GUESTBOOK_PROTECTION,
-                    'plugin_guestbook_url'             => $this->html_specialchars(strip_tags($serendipity['POST']['url'])),
-                    'plugin_guestbook_comment'         => $this->html_specialchars(strip_tags($serendipity['POST']['comment'])),
+                    'plugin_guestbook_url'             => serendipity_specialchars(strip_tags($serendipity['POST']['url'])),
+                    'plugin_guestbook_comment'         => serendipity_specialchars(strip_tags($serendipity['POST']['comment'])),
                     'plugin_guestbook_messagestack'    => $serendipity['messagestack']['comments'],
                     'plugin_guestbook_entry'           => array('timestamp' => 1)
                 )
@@ -1301,7 +1271,7 @@ class serendipity_event_guestbook extends serendipity_event {
 
                     if ($this->selected()) {
                         $serendipity['head_title']    = $this->get_config('headline');
-                        $serendipity['head_subtitle'] = $this->html_specialchars($serendipity['blogTitle']);
+                        $serendipity['head_subtitle'] = serendipity_specialchars($serendipity['blogTitle']);
                     }
                     break;
 

--- a/serendipity_event_guestbook/serendipity_event_guestbook.php
+++ b/serendipity_event_guestbook/serendipity_event_guestbook.php
@@ -73,16 +73,6 @@ class serendipity_event_guestbook extends serendipity_event {
         $this->filter_defaults = array('words'   => '\[link(.*?)\];http://');
     }
 
-
-    /**
-     * serendipity_plugin::example method
-     *
-     */
-    function example() {
-        return "\n<ul>\n    <li class=\"msg_notice\"><strong>Note to v. 3.53:</strong> If have, please update copied guestbook tpl files in your template!</li>\n    <li class=\"msg_notice\"><strong>Note to v. 3.50:</strong> A possible TABLE COLUMN order change for long time users, may need you to backup your database in Guestbooks DB Administration panel again!</li>\n</ul>\n\n";
-    }
-
-
     /**
      * serendipity_plugin::cleanup method
      *

--- a/serendipity_event_guestbook/serendipity_event_guestbook.php
+++ b/serendipity_event_guestbook/serendipity_event_guestbook.php
@@ -391,26 +391,6 @@ class serendipity_event_guestbook extends serendipity_event {
          return str_replace(array('@', '.'), array(' at ', ' dot '), $email);
     }
 
-
-    /**
-     * Check if email is valid
-     *
-     * @param  string   $string   entry email checks
-     * @return mixed    string/boolean
-     */
-     function is_valid_email($postmail) {
-        // Email needs to match this pattern to be a good email address
-        if (!empty($postmail)) {
-            return (preg_match(
-                ":^([-!#\$%&'*+./0-9=?A-Z^_`a-z{|}~ ])+" .    // the user name
-                "@" .                                        // the ubiquitous at-sign
-                "([-!#\$%&'*+/0-9=?A-Z^_`a-z{|}~ ]+\\.)+" . // host, sub-, and domain names
-                "[a-zA-Z]{2,6}\$:i",                         // top-level domain (TLD)
-                trim($postmail)));                            // get rid of trailing whitespace
-        } else return false;
-    }
-
-
     /**
      * Check POST string if guestbooks content filter found something to strip
      * Adds match to $serendipity['messagestack']['comments'] array, if not in admin group
@@ -855,7 +835,7 @@ class serendipity_event_guestbook extends serendipity_event {
             }
 
             if (isset($serendipity['POST']['email']) && !empty($serendipity['POST']['email']) && trim($serendipity['POST']['email']) != '') {
-                if (!$this->is_valid_email($serendipity['POST']['email'])) {
+                if (! filter_var($serendipity['POST']['email'], FILTER_VALIDATE_EMAIL)) {
                     array_push($messages, ERROR_NOVALIDEMAIL . ' <span class="gb_msgred">' . serendipity_specialchars($serendipity['POST']['email']) . '</span>');
                 } else {
                     $valid['data_email'] = TRUE;

--- a/serendipity_event_guestbook/serendipity_event_guestbook.php
+++ b/serendipity_event_guestbook/serendipity_event_guestbook.php
@@ -1465,15 +1465,15 @@ class serendipity_event_guestbook extends serendipity_event {
         }
 
         $moderate   = (serendipity_db_bool($this->get_config('showapp')) || serendipity_db_bool($this->get_config('automoderate'))) ? true : false;
-        $gbcat      = !empty($serendipity['GET']['guestbookcategory']) ? $serendipity['GET']['guestbookcategory'] : $serendipity['POST']['guestbookcategory'];
+        $gbcat      = !empty($serendipity['GET']['guestbookcategory'] ?? '') ? $serendipity['GET']['guestbookcategory'] ?? '' : $serendipity['POST']['guestbookcategory'] ?? '';
 
         if (!isset($serendipity['POST']['guestbookadmin'])) {
             $serendipity['smarty']->assign(
                 array(
                     'gb_liva'     => (!isset($serendipity['GET']['guestbookcategory']) || $serendipity['GET']['guestbookcategory'] == 'gbview') ? ' id="active"' : '',
-                    'gb_liapa'    => ($serendipity['GET']['guestbookcategory'] == 'gbapp' || ($serendipity['POST']['guestbook_category'] ?? '') == 'gbapp') ? ' id="active"' : '',
-                    'gb_liada'    => (($serendipity['GET']['guestbookcategory'] == 'gbadd' || ($serendipity['POST']['guestbookcategory'] ?? '') == 'gbadd') && ($serendipity['POST']['guestbook_category'] ?? '') != 'gbapp') ? ' id="active"' : '',
-                    'gb_lida'     => $serendipity['GET']['guestbookcategory'] == 'gbdb' ? ' id="active"' : '',
+                    'gb_liapa'    => (($serendipity['GET']['guestbookcategory'] ?? '') == 'gbapp' || ($serendipity['POST']['guestbook_category'] ?? '') == 'gbapp') ? ' id="active"' : '',
+                    'gb_liada'    => ((($serendipity['GET']['guestbookcategory'] ?? '') == 'gbadd' || ($serendipity['POST']['guestbookcategory'] ?? '') == 'gbadd') && ($serendipity['POST']['guestbook_category'] ?? '') != 'gbapp') ? ' id="active"' : '',
+                    'gb_lida'     => ($serendipity['GET']['guestbookcategory'] ?? '') == 'gbdb' ? ' id="active"' : '',
                     'gb_moderate' => $moderate,
                     'gb_isnav'    => true
                 )

--- a/serendipity_event_guestbook/serendipity_event_guestbook.php
+++ b/serendipity_event_guestbook/serendipity_event_guestbook.php
@@ -604,7 +604,7 @@ class serendipity_event_guestbook extends serendipity_event {
                                         ? 'http://' . $this->strip_security($entry['homepage'], null, true)
                                         : $this->strip_security($entry['homepage'], null, true);
                 $entry['pluginpath']    = $serendipity['serendipityHTTPPath'] . $serendipity['guestbook']['pluginpath'];
-                $entry['timestamp']     = strftime($this->get_config('dateformat'), (int)$entry['timestamp']); // mysql would use SELECT *, FROM_UNIXTIME(timestamp) AS ts FROM `s9y_guestbook`
+                $entry['timestamp']     = PHP81_BC\strftime($this->get_config('dateformat'), (int)$entry['timestamp']); // mysql would use SELECT *, FROM_UNIXTIME(timestamp) AS ts FROM `s9y_guestbook`
 
                 $entry['page']          = $is_guestbook_url . (($serendipity['rewrite'] == 'rewrite') ? '?' : '&') . 'noclean=true&serendipity[adminAction]=guestbookdelete&serendipity[page]=' . (int)$serendipity['GET']['page'] . '&serendipity[gbid]=' . $entry['id'];
 
@@ -659,8 +659,8 @@ class serendipity_event_guestbook extends serendipity_event {
         $ts    = isset($ts)  ? $ts   : time();
 
         $name  = serendipity_db_escape_string(substr($name, 0, 29));
-        $url   = serendipity_db_escape_string(substr($url, 0, 99));
-        $email = serendipity_db_escape_string(substr($email, 0, 99));
+        $url   = serendipity_db_escape_string(substr($url ?? '', 0, 99));
+        $email = serendipity_db_escape_string(substr($email ?? '', 0, 99));
         $body  = serendipity_db_escape_string($body);
 
         if ($old === false) {
@@ -789,7 +789,7 @@ class serendipity_event_guestbook extends serendipity_event {
         }
         // if force moderate is set to moderate, advice security to not support 'stripped' or 'stripped-by-key' POST mark
         // this does only happen true, if not automoderate is set in both plugins and strip tags really removed some tags.
-        if (isset($serendipity[$forcemoderate[0]]) == 'moderate' && $gb_automoderate === true) {
+        if (isset ($forcemoderate) && $serendipity[$forcemoderate[0]] == 'moderate' && $gb_automoderate === true) {
             $serendipity['POST'] = $this->strip_security($serendipity['POST'], array('name', 'email', 'comment', 'admincomment', 'url'), false, false);
         } else {
             $serendipity['POST'] = $this->strip_security($serendipity['POST'], array('name', 'email', 'comment', 'admincomment', 'url'));
@@ -1088,11 +1088,11 @@ class serendipity_event_guestbook extends serendipity_event {
                     'plugin_guestbook_sent'            => $this->get_config('sent', PLUGIN_GUESTBOOK_SENT_HTML),
                     'plugin_guestbook_action'          => $serendipity['baseURL'] . $serendipity['indexFile'],
                     'plugin_guestbook_sname'           => serendipity_specialchars($serendipity['GET']['subpage']),
-                    'plugin_guestbook_name'            => serendipity_specialchars(strip_tags($serendipity['POST']['name'])),
-                    'plugin_guestbook_email'           => serendipity_specialchars(strip_tags($serendipity['POST']['email'])),
+                    'plugin_guestbook_name'            => serendipity_specialchars(strip_tags($serendipity['POST']['name'] ?? '')),
+                    'plugin_guestbook_email'           => serendipity_specialchars(strip_tags($serendipity['POST']['email'] ?? '')),
                     'plugin_guestbook_emailprotect'    => PLUGIN_GUESTBOOK_PROTECTION,
-                    'plugin_guestbook_url'             => serendipity_specialchars(strip_tags($serendipity['POST']['url'])),
-                    'plugin_guestbook_comment'         => serendipity_specialchars(strip_tags($serendipity['POST']['comment'])),
+                    'plugin_guestbook_url'             => serendipity_specialchars(strip_tags($serendipity['POST']['url'] ?? '')),
+                    'plugin_guestbook_comment'         => serendipity_specialchars(strip_tags($serendipity['POST']['comment'] ?? '')),
                     'plugin_guestbook_messagestack'    => $serendipity['messagestack']['comments'],
                     'plugin_guestbook_entry'           => array('timestamp' => 1)
                 )

--- a/serendipity_event_guestbook/serendipity_event_guestbook.php
+++ b/serendipity_event_guestbook/serendipity_event_guestbook.php
@@ -266,7 +266,7 @@ class serendipity_event_guestbook extends serendipity_event {
                 break;
 
             case 'intro':
-                $propbag->add('type', ($serendipity['wysiwyg'] === true ? 'html' : 'text'));
+                $propbag->add('type', (($serendipity['wysiwyg'] ?? false) === true ? 'html' : 'text'));
                 $propbag->add('rows', 3);
                 $propbag->add('name',        PLUGIN_GUESTBOOK_INTRO);
                 $propbag->add('description', '');
@@ -690,7 +690,7 @@ class serendipity_event_guestbook extends serendipity_event {
      * @param  boolean   $old    Insert/Replace
      * @return boolean
      */
-    function insertEntriesDB($id=false, $ip=false, $name, $url, $email, $body, $app=false, $ts=false, $old=false) {
+    function insertEntriesDB($id, $ip, $name, $url, $email, $body, $app=false, $ts=false, $old=false) {
         global $serendipity;
 
         // make php to current unix timestamp to insert into db
@@ -1290,7 +1290,7 @@ class serendipity_event_guestbook extends serendipity_event {
                         $this->alter_db($cur);
                         $this->set_config('dbversion', '5');
                     } elseif ($cur == '5') {
-                        continue;
+                        break;
                     } else {
                         $this->install();
                         $this->set_config('dbversion', '5');

--- a/serendipity_event_guestbook/serendipity_event_guestbook.php
+++ b/serendipity_event_guestbook/serendipity_event_guestbook.php
@@ -55,7 +55,7 @@ class serendipity_event_guestbook extends serendipity_event {
                         'dateformat'
                     ));
         $propbag->add('author',       'Ian');
-        $propbag->add('version',      '3.61.2');
+        $propbag->add('version',      '3.61.3');
         $propbag->add('requirements', array(
                         'serendipity' => '1.7.0',
                         'smarty'      => '3.1.0',

--- a/serendipity_event_guestbook/serendipity_plugin_guestbook.php
+++ b/serendipity_event_guestbook/serendipity_plugin_guestbook.php
@@ -177,8 +177,8 @@ class serendipity_plugin_guestbook extends serendipity_plugin {
         $entries = serendipity_db_query($sql);
         if (!empty($entries) && is_array($entries)) {
             foreach($entries AS $row) {
-                echo '<time>' . serendipity_event_guestbook::html_specialchars(serendipity_strftime($dateformat, $row['timestamp'])) . "</time>\n";
-                $row['body'] = serendipity_event_guestbook::html_specialchars($row['body']);
+                echo '<time>' . serendipity_specialchars(serendipity_strftime($dateformat, $row['timestamp'])) . "</time>\n";
+                $row['body'] = serendipity_specialchars($row['body']);
                 $row['body'] = serendipity_event_guestbook::bbc_reverse($row['body']);
                 $row['body'] = trim(preg_replace('/\s+/', ' ', $row['body']));
 
@@ -197,16 +197,16 @@ class serendipity_plugin_guestbook extends serendipity_plugin {
                 serendipity_plugin_api::hook_event('frontend_display', $entry); */
 
                 echo '<div class="guestbook_sidebar_comment">' . $row['body'] . "</div>\n"; // Care: use $entry['comment'] with hook!
-                echo '<div class="guestbook_sidebar_name"><strong>' . serendipity_event_guestbook::html_specialchars($row['name']) . "</strong></div>\n";
+                echo '<div class="guestbook_sidebar_name"><strong>' . serendipity_specialchars($row['name']) . "</strong></div>\n";
 
                 if ($showemail){
-                    $_email = serendipity_event_guestbook::html_specialchars($row['email']);
+                    $_email = serendipity_specialchars($row['email']);
                     $email  = $serendipity['serendipityUserlevel'] < USERLEVEL_ADMIN ? str_replace(array('@', '.'), array(' at ', ' dot '), $_email) : $_email;
-                    echo '<div class="guestbook_sidebar_email"><a href="mailto:' . $email . '">' . serendipity_event_guestbook::html_specialchars($row['email']) . "</a></div>\n";
+                    echo '<div class="guestbook_sidebar_email"><a href="mailto:' . $email . '">' . serendipity_specialchars($row['email']) . "</a></div>\n";
                 }
 
                 if ($showhomepage) {
-                    echo '<div class="guestbook_sidebar_url"><a href="' . serendipity_event_guestbook::html_specialchars($row['homepage']) . '">' . serendipity_event_guestbook::html_specialchars($row['homepage']) . "</a></div>\n";
+                    echo '<div class="guestbook_sidebar_url"><a href="' . serendipity_specialchars($row['homepage']) . '">' . serendipity_specialchars($row['homepage']) . "</a></div>\n";
                 }
 
                 echo "<div class=\"guestbook_sidebar_spacer\">&nbsp;</div>\n\n";

--- a/serendipity_event_guestbook/serendipity_plugin_guestbook.php
+++ b/serendipity_event_guestbook/serendipity_plugin_guestbook.php
@@ -22,7 +22,7 @@ class serendipity_plugin_guestbook extends serendipity_plugin {
         $propbag->add('description',   PLUGIN_GUESTSIDE_BLAHBLAH);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Jaap Boerma ( j@webbict.com ), Tadashi Jokagi <elf2000@users.sourceforge.net>, Ian');
-        $propbag->add('version',       '1.26.2');
+        $propbag->add('version',       '1.26.3');
         $propbag->add('requirements', array(
                         'serendipity' => '0.7',
                         'smarty'      => '2.6.7',

--- a/serendipity_event_guestbook/serendipity_plugin_guestbook.php
+++ b/serendipity_event_guestbook/serendipity_plugin_guestbook.php
@@ -13,7 +13,7 @@ if (IN_serendipity !== true) {
 
 class serendipity_plugin_guestbook extends serendipity_plugin {
     var $title = PLUGIN_GUESTSIDE_NAME;
-    #var $conty = array('%serendipity_event_guestbook%/showapp', '%serendipity_event_guestbook%/automoderate');
+    var $dependencies = null;
 
     function introspect(&$propbag) {
         global $serendipity;


### PR DESCRIPTION
Fixes multiple warnings that the plugin produces under PHP 8, including the one reported in https://github.com/s9y/Serendipity/issues/718.

Also replaces the custom email check with `filter_var` and makes use of the cores `serendipity_specialchar` instead of using a copy inside the plugin code.