### PR TITLE
sitemap 0.61.4: Fix error with null timespams on PHP 8

### DIFF
--- a/serendipity_event_google_sitemap/ChangeLog
+++ b/serendipity_event_google_sitemap/ChangeLog
@@ -1,3 +1,7 @@
+0.61.4:
+-----
+    * Fix sitemap creation with NULL timestamps on PHP 8
+
 0.61.3:
 -----
     * PHP 8 fix for opening the plugin configuration

--- a/serendipity_event_google_sitemap/serendipity_event_google_sitemap.php
+++ b/serendipity_event_google_sitemap/serendipity_event_google_sitemap.php
@@ -308,7 +308,7 @@ class serendipity_event_google_sitemap extends serendipity_event {
 
             // add entries
             foreach($entries as $entry) {
-                $max = max($entry['timestamp_1']+0, $entry['timestamp_2']+0);
+                $max = max(intval($entry['timestamp_1']), intval($entry['timestamp_2']));
                 $url = serendipity_archiveURL($entry['id'], $entry['title']);
                 $props = serendipity_fetchEntryProperties($entry['id']);                
                 $props['title'] = $entry['title'];

--- a/serendipity_event_google_sitemap/serendipity_event_google_sitemap.php
+++ b/serendipity_event_google_sitemap/serendipity_event_google_sitemap.php
@@ -24,7 +24,7 @@ class serendipity_event_google_sitemap extends serendipity_event {
         $propbag->add('name', PLUGIN_EVENT_SITEMAP_TITLE);
         $propbag->add('description', PLUGIN_EVENT_SITEMAP_DESC);
         $propbag->add('author', 'Boris');
-        $propbag->add('version', '0.61.3');
+        $propbag->add('version', '0.61.4');
         $propbag->add('event_hooks',  array(
                 'backend_publish' => true,
                 'backend_save'    => true,


### PR DESCRIPTION
Using proper intval() when estimating most recent timestamp. This won't crash on NULL values.

This is a cleaned up PR copy of https://github.com/s9y/additional_plugins/pull/168.