### PR TITLE
timezones 1.0: Avoid PHP error, use DateTime instead of Date.php

### DIFF
--- a/serendipity_plugin_timezones/ChangeLog
+++ b/serendipity_plugin_timezones/ChangeLog
@@ -1,3 +1,11 @@
+1.0:
+----
+* Rework date format approach for modern PHP
+    * to avoid an error under
+    * and no longer rely on a manually supplied Date.php
+* Drop manual timezone offsets. Proper timezone support (like Europe/Berlin) can
+  be used instead
+
 0.6.1:
 ----
 * Hotfixes for PHP 8 (surrim)

--- a/serendipity_plugin_timezones/UTF-8/lang_bg.inc.php
+++ b/serendipity_plugin_timezones/UTF-8/lang_bg.inc.php
@@ -16,7 +16,7 @@
 @define('PLUGIN_TIMEZONES_ZONE1_NAME',                  'Код на първа зона');
 @define('PLUGIN_TIMEZONES_ZONE1_NAME_BLABLAH',          'Код на първата зона. (например CET)');
 @define('PLUGIN_TIMEZONES_ZONE1_FORMAT',                'Формат на времето за първа зона');
-@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',        'Форматиращ стринг, както се иска от PEAR::Date (Вижте http://pear.php.net/package/Date/docs/1.4.5/apidoc/Date/Date.html#methodformat)');
+@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',        'Форматиращ стринг, както се иска от PEAR::Date (Вижте https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters)');
 
 @define('PLUGIN_TIMEZONES_ZONE2_TEXT',                  'Втора зона');
 @define('PLUGIN_TIMEZONES_ZONE2_TEXT_BLABLAH',          'Място (държава/град) на втората зона.');

--- a/serendipity_plugin_timezones/UTF-8/lang_cs.inc.php
+++ b/serendipity_plugin_timezones/UTF-8/lang_cs.inc.php
@@ -15,7 +15,7 @@
 @define('PLUGIN_TIMEZONES_ZONE1_NAME',		'Název prvního pásma');
 @define('PLUGIN_TIMEZONES_ZONE1_NAME_BLABLAH',		'Krátký název pro první časové pásmo (např. SELČ = StředoEvropský Letní Čas)');
 @define('PLUGIN_TIMEZONES_ZONE1_FORMAT',		'Formát prvního časového pásma');
-@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',		'Formátovací řetězec předaný php kódu, viz. http://pear.php.net/package/Date/docs/1.4.5/apidoc/Date/Date.html#methodformat a nebo http://uk2.php.net/date (pokud není možn époužít PEAR)');
+@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',		'Formátovací řetězec předaný php kódu, viz. https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters');
 
 @define('PLUGIN_TIMEZONES_TIMESHIFT1',		'Posun prvního pásma');
 @define('PLUGIN_TIMEZONES_TIMESHIFT1_BLABLAH',		"Posun v SEKUNDÁCH vůči času serveru (pouze pokud PEAR::Date not available).");

--- a/serendipity_plugin_timezones/UTF-8/lang_cz.inc.php
+++ b/serendipity_plugin_timezones/UTF-8/lang_cz.inc.php
@@ -15,7 +15,7 @@
 @define('PLUGIN_TIMEZONES_ZONE1_NAME',		'Název prvního pásma');
 @define('PLUGIN_TIMEZONES_ZONE1_NAME_BLABLAH',		'Krátký název pro první časové pásmo (např. SELČ = StředoEvropský Letní Čas)');
 @define('PLUGIN_TIMEZONES_ZONE1_FORMAT',		'Formát prvního časového pásma');
-@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',		'Formátovací řetězec předaný php kódu, viz. http://pear.php.net/package/Date/docs/1.4.5/apidoc/Date/Date.html#methodformat a nebo http://uk2.php.net/date (pokud není možn époužít PEAR)');
+@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',		'Formátovací řetězec předaný php kódu, viz. https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters');
 
 @define('PLUGIN_TIMEZONES_TIMESHIFT1',		'Posun prvního pásma');
 @define('PLUGIN_TIMEZONES_TIMESHIFT1_BLABLAH',		"Posun v SEKUNDÁCH vůči času serveru (pouze pokud PEAR::Date not available).");

--- a/serendipity_plugin_timezones/UTF-8/lang_de.inc.php
+++ b/serendipity_plugin_timezones/UTF-8/lang_de.inc.php
@@ -15,7 +15,7 @@
 @define('PLUGIN_TIMEZONES_ZONE1_NAME',                  "Erste Zeitzone");
 @define('PLUGIN_TIMEZONES_ZONE1_NAME_BLABLAH',          "Kurzname der ersten Zeitzone, z.B. CET");
 @define('PLUGIN_TIMEZONES_ZONE1_FORMAT',                "Format der ersten Zeitzone");
-@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',        "Format wird an PHP übergeben, siehe see http://pear.php.net/package/Date/docs/1.4.5/apidoc/Date/Date.html#methodformat oder http://de.php.net/date");
+@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',        "Format wird an PHP übergeben, siehe https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters");
 
 @define('PLUGIN_TIMEZONES_TIMESHIFT1',                  "Zeitverschiebung (erste Zeitzone)");
 @define('PLUGIN_TIMEZONES_TIMESHIFT1_BLABLAH',          "Die Zeitverschiebung in SEKUNDEN ggü. der lokalen Serverzeit (wird nur verwendet, wenn PEAR::Date nicht verfügbar ist).");

--- a/serendipity_plugin_timezones/lang_bg.inc.php
+++ b/serendipity_plugin_timezones/lang_bg.inc.php
@@ -16,7 +16,7 @@
 @define('PLUGIN_TIMEZONES_ZONE1_NAME',                  'Код на първа зона');
 @define('PLUGIN_TIMEZONES_ZONE1_NAME_BLABLAH',          'Код на първата зона. (например CET)');
 @define('PLUGIN_TIMEZONES_ZONE1_FORMAT',                'Формат на времето за първа зона');
-@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',        'Форматиращ стринг, както се иска от PEAR::Date (Вижте http://pear.php.net/package/Date/docs/1.4.5/apidoc/Date/Date.html#methodformat)');
+@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',        'Форматиращ стринг, както се иска от PEAR::Date (Вижте https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters)');
 
 @define('PLUGIN_TIMEZONES_ZONE2_TEXT',                  'Втора зона');
 @define('PLUGIN_TIMEZONES_ZONE2_TEXT_BLABLAH',          'Място (държава/град) на втората зона.');

--- a/serendipity_plugin_timezones/lang_cs.inc.php
+++ b/serendipity_plugin_timezones/lang_cs.inc.php
@@ -15,7 +15,7 @@
 @define('PLUGIN_TIMEZONES_ZONE1_NAME',		'Název prvního pásma');
 @define('PLUGIN_TIMEZONES_ZONE1_NAME_BLABLAH',		'Krátký název pro první èasové pásmo (napø. SELÈ = StøedoEvropský Letní Èas)');
 @define('PLUGIN_TIMEZONES_ZONE1_FORMAT',		'Formát prvního èasového pásma');
-@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',		'Formátovací øetìzec pøedaný php kódu, viz. http://pear.php.net/package/Date/docs/1.4.5/apidoc/Date/Date.html#methodformat a nebo http://uk2.php.net/date (pokud není možn époužít PEAR)');
+@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',		'Formátovací øetìzec pøedaný php kódu, viz. https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters');
 
 @define('PLUGIN_TIMEZONES_TIMESHIFT1',		'Posun prvního pásma');
 @define('PLUGIN_TIMEZONES_TIMESHIFT1_BLABLAH',		"Posun v SEKUNDÁCH vùèi èasu serveru (pouze pokud PEAR::Date not available).");

--- a/serendipity_plugin_timezones/lang_cz.inc.php
+++ b/serendipity_plugin_timezones/lang_cz.inc.php
@@ -15,7 +15,7 @@
 @define('PLUGIN_TIMEZONES_ZONE1_NAME',		'Název prvního pásma');
 @define('PLUGIN_TIMEZONES_ZONE1_NAME_BLABLAH',		'Krátký název pro první èasové pásmo (napø. SELÈ = StøedoEvropský Letní Èas)');
 @define('PLUGIN_TIMEZONES_ZONE1_FORMAT',		'Formát prvního èasového pásma');
-@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',		'Formátovací øetìzec pøedaný php kódu, viz. http://pear.php.net/package/Date/docs/1.4.5/apidoc/Date/Date.html#methodformat a nebo http://uk2.php.net/date (pokud není mo¾n épou¾ít PEAR)');
+@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',		'Formátovací øetìzec pøedaný php kódu, viz. https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters');
 
 @define('PLUGIN_TIMEZONES_TIMESHIFT1',		'Posun prvního pásma');
 @define('PLUGIN_TIMEZONES_TIMESHIFT1_BLABLAH',		"Posun v SEKUNDÁCH vùèi èasu serveru (pouze pokud PEAR::Date not available).");

--- a/serendipity_plugin_timezones/lang_de.inc.php
+++ b/serendipity_plugin_timezones/lang_de.inc.php
@@ -15,7 +15,7 @@
 @define('PLUGIN_TIMEZONES_ZONE1_NAME',                  "Erste Zeitzone");
 @define('PLUGIN_TIMEZONES_ZONE1_NAME_BLABLAH',          "Kurzname der ersten Zeitzone, z.B. CET");
 @define('PLUGIN_TIMEZONES_ZONE1_FORMAT',                "Format der ersten Zeitzone");
-@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',        "Format wird an PHP übergeben, siehe see http://pear.php.net/package/Date/docs/1.4.5/apidoc/Date/Date.html#methodformat oder http://de.php.net/date");
+@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',        "Format wird an PHP übergeben, siehe https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters");
 
 @define('PLUGIN_TIMEZONES_TIMESHIFT1',                  "Zeitverschiebung (erste Zeitzone)");
 @define('PLUGIN_TIMEZONES_TIMESHIFT1_BLABLAH',          "Die Zeitverschiebung in SEKUNDEN ggü. der lokalen Serverzeit (wird nur verwendet, wenn PEAR::Date nicht verfügbar ist).");

--- a/serendipity_plugin_timezones/lang_en.inc.php
+++ b/serendipity_plugin_timezones/lang_en.inc.php
@@ -16,7 +16,7 @@
 @define('PLUGIN_TIMEZONES_ZONE1_NAME',                  "First zone");
 @define('PLUGIN_TIMEZONES_ZONE1_NAME_BLABLAH',          "Shortname for the first timezone. (e.g. CET)");
 @define('PLUGIN_TIMEZONES_ZONE1_FORMAT',                "Format of the first timezone");
-@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',        "Formatstring passed to php, see http://pear.php.net/package/Date/docs/1.4.5/apidoc/Date/Date.html#methodformat or http://uk2.php.net/date (if PEAR is not Available)");
+@define('PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH',        "Formatstring passed to php, see https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters");
 
 @define('PLUGIN_TIMEZONES_TIMESHIFT1',                  "First Timeshift");
 @define('PLUGIN_TIMEZONES_TIMESHIFT1_BLABLAH',          "The timeshift in SECONDS from local machine time(only used when PEAR::Date not available).");

--- a/serendipity_plugin_timezones/serendipity_plugin_timezones.php
+++ b/serendipity_plugin_timezones/serendipity_plugin_timezones.php
@@ -12,17 +12,17 @@ class serendipity_plugin_timezones extends serendipity_plugin {
     function introspect(&$propbag) {
         $propbag->add('name',           PLUGIN_TIMEZONES_TITLE);
         $propbag->add('description',    PLUGIN_TIMEZONES_BLAHBLAH);
-        $propbag->add('configuration',  array('title', 'zone1_text', 'zone1_name', 'zone1_format', 'timeshift1',
-                                                       'zone2_text', 'zone2_name', 'zone2_format', 'timeshift2',
-                            'zone3_text', 'zone3_name', 'zone3_format', 'timeshift3',
-                            'zone4_text', 'zone4_name', 'zone4_format', 'timeshift4'));
+        $propbag->add('configuration',  array('title', 'zone1_text', 'zone1_name', 'zone1_format',
+                                                       'zone2_text', 'zone2_name', 'zone2_format',
+                            'zone3_text', 'zone3_name', 'zone3_format',
+                            'zone4_text', 'zone4_name', 'zone4_format'));
         $propbag->add('author',         'Christoph Eunicke <s9y-plugin@eunicke.org>');
         $propbag->add('stackable',      true);
-        $propbag->add('version',        '0.6.1');
+        $propbag->add('version',        '1.0');
         $propbag->add('requirements',  array(
             'serendipity' => '0.9',
             'smarty'      => '2.6.7',
-            'php'         => '4.1.0'
+            'php'         => '5.2.0'
         ));
         $propbag->add('groups', array('FRONTEND_FEATURES'));
     }
@@ -68,7 +68,7 @@ class serendipity_plugin_timezones extends serendipity_plugin {
                 $propbag->add('type',           'string');
                 $propbag->add('name',           PLUGIN_TIMEZONES_ZONE1_NAME);
                 $propbag->add('description',    PLUGIN_TIMEZONES_ZONE1_NAME_BLABLAH);
-                $propbag->add('default',        'WEST');
+                $propbag->add('default',        'Europe/Berlin');
                 break;
 
             case 'zone2_name':
@@ -96,14 +96,14 @@ class serendipity_plugin_timezones extends serendipity_plugin {
                 $propbag->add('type',           'string');
                 $propbag->add('name',           PLUGIN_TIMEZONES_ZONE1_FORMAT);
                 $propbag->add('description',    PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH);
-                $propbag->add('default',        '%T');
+                $propbag->add('default',        'H:i');
                 break;
 
             case 'zone2_format':
                 $propbag->add('type',           'string');
                 $propbag->add('name',           PLUGIN_TIMEZONES_ZONE2_FORMAT);
                 $propbag->add('description',    PLUGIN_TIMEZONES_ZONE1_FORMAT_BLABLAH);
-                $propbag->add('default',        '%T');
+                $propbag->add('default',        'H:i');
                 break;
 
             case 'zone3_format':
@@ -120,35 +120,6 @@ class serendipity_plugin_timezones extends serendipity_plugin {
                 $propbag->add('default',        '');
                 break;
 
-            case 'timeshift1':
-                $propbag->add('type',           'string');
-                $propbag->add('name',           PLUGIN_TIMEZONES_TIMESHIFT1);
-                $propbag->add('description',    PLUGIN_TIMEZONES_TIMESHIFT1_BLABLAH);
-                $propbag->add('default',        '');
-                break;
-
-            case 'timeshift2':
-                $propbag->add('type',           'string');
-                $propbag->add('name',           PLUGIN_TIMEZONES_TIMESHIFT2);
-                $propbag->add('description',    PLUGIN_TIMEZONES_TIMESHIFT1_BLABLAH);
-                $propbag->add('default',        '');
-                break;
-
-            case 'timeshift3':
-                $propbag->add('type',           'string');
-                $propbag->add('name',           PLUGIN_TIMEZONES_TIMESHIFT3);
-                $propbag->add('description',    PLUGIN_TIMEZONES_TIMESHIFT1_BLABLAH);
-                $propbag->add('default',        '');
-                break;
-
-            case 'timeshift4':
-                $propbag->add('type',           'string');
-                $propbag->add('name',           PLUGIN_TIMEZONES_TIMESHIFT4);
-                $propbag->add('description',    PLUGIN_TIMEZONES_TIMESHIFT1_BLABLAH);
-                $propbag->add('default',        '');
-                break;
-
-
             default:
                 return false;
         }
@@ -159,58 +130,25 @@ class serendipity_plugin_timezones extends serendipity_plugin {
         global $serendipity;
 
         $title = $this->get_config('title');
-
-        if (($this->get_config('timeshift1') == "" ||
-            $this->get_config('timeshift2') == "" ||
-            $this->get_config('timeshift3') == "" ||
-            $this->get_config('timeshift4') == "" ) &&
-            @include_once 'Date.php') {
-
-            $date = new Date();
-            //create the first date
-
-            $date->convertTZbyID($this->get_config('zone1_name'));
-            $date1=$date->format($this->get_config('zone1_format'));
-
-            $date->convertTZbyID($this->get_config('zone2_name'));
-            $date2=$date->format($this->get_config('zone2_format'));
-
-            $date->convertTZbyID($this->get_config('zone3_name'));
-            $date3=$date->format($this->get_config('zone3_format'));
-
-            $date->convertTZbyID($this->get_config('zone4_name'));
-            $date4=$date->format($this->get_config('zone4_format'));
-        } else {
-            $date1=date($this->get_config('zone1_format'),time()+$this->get_config('timeshift1'));
-            $date2=date($this->get_config('zone2_format'),time()+$this->get_config('timeshift2'));
-            $date3=date($this->get_config('zone3_format'),time()+$this->get_config('timeshift3'));
-            $date4=date($this->get_config('zone4_format'),time()+$this->get_config('timeshift4'));
-        }
+        $d = new DateTimeImmutable();
+        $timezoneIds = [$this->get_config('zone1_name'), $this->get_config('zone2_name'), $this->get_config('zone3_name'), $this->get_config('zone4_name')];
 
         echo '<ul class="plainList">';
-        echo '<li>';
-        echo $this->get_config('zone1_text');
-        echo $date1;
-        echo '</li>';
-
-        echo '<li>';
-        echo $this->get_config('zone2_text');
-        echo $date2;
-        echo '</li>';
-   
-        if ($this->get_config('zone3_text') !== ""){ //Third zone required
-            echo '<li>';
-            echo $this->get_config('zone3_text');
-            echo $date3;
-            echo '</li>';
-
-            if ($this->get_config('zone4_text') !== ""){ //Fourth zone required
+        $i = 0;
+        foreach ($timezoneIds as $timezoneId) {
+            $i += 1;
+            if ($timezoneId) {
+                $tzo = new DateTimeZone($timezoneId);
+                $local = $d->setTimezone($tzo);
+                
                 echo '<li>';
-                echo $this->get_config('zone4_text');
-                echo $date4;
+                echo $this->get_config("zone{$i}_text");
+                echo ' ';
+                echo $local->format( $this->get_config("zone{$i}_format"));
                 echo '</li>';
             }
         }
+
         echo '</ul>';
     }
 } 


### PR DESCRIPTION
https://board.s9y.org/viewtopic.php?p=10459385#p10459385 reported that the timezones plugin broke under PHP 8.4. The plugin used two different approach for its work, either https://pear.php.net/package/Date, but without actually including the needed Date.php file, or a `time()` with offset approach. This PR instead uses `DateTimeImmutable` with timezone names (these: https://www.php.net/manual/de/timezones.php) and drops the manual offset.