### PR TITLE
statistics sidebar 1.6.1: Avoid crash when database tabels missing

### DIFF
--- a/serendipity_event_statistics/ChangeLog
+++ b/serendipity_event_statistics/ChangeLog
@@ -1,3 +1,4 @@
+1.6.1 (sidebar): Avoid fatal error when database table missing
 1.66.1: Fixed broken admin page with PHP8 when comments empty
 1.66: Fixed broken admin page with PHP8
 1.65: Added legal gdpr/dsgvo info

--- a/serendipity_event_statistics/serendipity_plugin_statistics.php
+++ b/serendipity_event_statistics/serendipity_plugin_statistics.php
@@ -213,23 +213,35 @@ class serendipity_plugin_statistics extends serendipity_plugin
             }
 
             if (serendipity_db_bool($this->get_config('show_monthvisitors'))) {
-                $res = serendipity_db_query("SELECT sum(visits) AS monthvisitors FROM {$serendipity['dbPrefix']}visitors_count WHERE year='".$year."' AND month='".$month."'", true, 'assoc');
-                if (is_array($res) && isset($res['monthvisitors'])) {
-                    $content .= '<div class="stat_monthvisitors">' . sprintf($this->get_config('text_monthvisitors'), '<span class="stat_number">' . $res['monthvisitors'] . '</span>') . "</div>\n";
+                try {
+                    $res = serendipity_db_query("SELECT sum(visits) AS monthvisitors FROM {$serendipity['dbPrefix']}visitors_count WHERE year='".$year."' AND month='".$month."'", true, 'assoc');
+                    if (is_array($res) && isset($res['monthvisitors'])) {
+                        $content .= '<div class="stat_monthvisitors">' . sprintf($this->get_config('text_monthvisitors'), '<span class="stat_number">' . $res['monthvisitors'] . '</span>') . "</div>\n";
+                    }
+                } catch (Exception $ex) {
+                    // It is possible the visitor_count table does not exist. This will then throw an exception, but which one depends
+                    // on the used database. So we catch all possible Exceptions here. We can't really do anything with it regardless.
                 }
             }
 
             if (serendipity_db_bool($this->get_config('show_weekvisitors'))) {
-                $res = serendipity_db_query("SELECT sum(visits) AS weekvisitors FROM {$serendipity['dbPrefix']}visitors_count WHERE CONCAT(year,month,day) >= '".$lastmonday."' AND CONCAT(year,month,day) <= '".$nextsunday."'", true, 'assoc');
-                if (is_array($res) && isset($res['weekvisitors'])) {
-                    $content .= '<div class="stat_weekhvisitors">' . sprintf($this->get_config('text_weekvisitors'), '<span class="stat_number">' . $res['weekvisitors'] . '</span>') . "</div>\n";
+                try {
+                    $res = serendipity_db_query("SELECT sum(visits) AS weekvisitors FROM {$serendipity['dbPrefix']}visitors_count WHERE CONCAT(year,month,day) >= '".$lastmonday."' AND CONCAT(year,month,day) <= '".$nextsunday."'", true, 'assoc');
+                    if (is_array($res) && isset($res['weekvisitors'])) {
+                        $content .= '<div class="stat_weekhvisitors">' . sprintf($this->get_config('text_weekvisitors'), '<span class="stat_number">' . $res['weekvisitors'] . '</span>') . "</div>\n";
+                    }
+                } catch (Exception $ex) {
                 }
+                
             }
 
             if (serendipity_db_bool($this->get_config('show_dayvisitors'))) {
-                $res = serendipity_db_query("SELECT sum(visits) AS dayvisitors FROM {$serendipity['dbPrefix']}visitors_count WHERE year='".$year."' AND month='".$month."' AND day='".$day."'", true, 'assoc');
-                if (is_array($res) && isset($res['dayvisitors'])) {
-                    $content .= '<div class="stat_dayhvisitors">' . sprintf($this->get_config('text_dayvisitors'), '<span class="stat_number">' . $res['dayvisitors'] . '</span>') . "</div>\n";
+                try {
+                    $res = serendipity_db_query("SELECT sum(visits) AS dayvisitors FROM {$serendipity['dbPrefix']}visitors_count WHERE year='".$year."' AND month='".$month."' AND day='".$day."'", true, 'assoc');
+                    if (is_array($res) && isset($res['dayvisitors'])) {
+                        $content .= '<div class="stat_dayhvisitors">' . sprintf($this->get_config('text_dayvisitors'), '<span class="stat_number">' . $res['dayvisitors'] . '</span>') . "</div>\n";
+                    }
+                } catch (Exception $ex) {
                 }
             }
 
@@ -250,9 +262,12 @@ class serendipity_plugin_statistics extends serendipity_plugin
                     $min_ts = date('Hi', $min);
                     $q   = "SELECT count(counter_id) AS currentvisitors FROM {$serendipity['dbPrefix']}visitors WHERE day LIKE '" . date('Y-m-d') . "' AND (REPLACE(time, ':', '') BETWEEN $min_ts AND $max_ts)";
                 }
-                $res = serendipity_db_query($q, true, 'assoc');
-                if (is_array($res) && isset($res['currentvisitors'])) {
-                    $content .= '<div class="stat_currentvisitors">' . sprintf($this->get_config('text_currentvisitors'), '<span class="stat_number">' . $res['currentvisitors'] . '</span>') . "</div>\n";
+                try {
+                    $res = serendipity_db_query($q, true, 'assoc');
+                    if (is_array($res) && isset($res['currentvisitors'])) {
+                        $content .= '<div class="stat_currentvisitors">' . sprintf($this->get_config('text_currentvisitors'), '<span class="stat_number">' . $res['currentvisitors'] . '</span>') . "</div>\n";
+                    }
+                } catch (Exception $ex) {
                 }
             }
 

--- a/serendipity_event_statistics/serendipity_plugin_statistics.php
+++ b/serendipity_event_statistics/serendipity_plugin_statistics.php
@@ -18,7 +18,7 @@ class serendipity_plugin_statistics extends serendipity_plugin
         $propbag->add('description',   PLUGIN_EVENT_STATISTICS_NAME);
         $propbag->add('stackable',     true);
         $propbag->add('author',        'Arnan de Gans, Garvin Hicking');
-        $propbag->add('version',       '1.6');
+        $propbag->add('version',       '1.6.1');
         $propbag->add('requirements',  array(
             'serendipity' => '1.7',
             'smarty'      => '2.6.7',

--- a/serendipity_event_statistics/serendipity_plugin_statistics.php
+++ b/serendipity_event_statistics/serendipity_plugin_statistics.php
@@ -220,7 +220,8 @@ class serendipity_plugin_statistics extends serendipity_plugin
                     }
                 } catch (Exception $ex) {
                     // It is possible the visitor_count table does not exist. This will then throw an exception, but which one depends
-                    // on the used database. So we catch all possible Exceptions here. We can't really do anything with it regardless.
+                    // on the used database. So we catch all possible Exceptions here.
+                    $content .= '<div class="stat_monthvisitors">Missing data</div>';
                 }
             }
 
@@ -231,6 +232,7 @@ class serendipity_plugin_statistics extends serendipity_plugin
                         $content .= '<div class="stat_weekhvisitors">' . sprintf($this->get_config('text_weekvisitors'), '<span class="stat_number">' . $res['weekvisitors'] . '</span>') . "</div>\n";
                     }
                 } catch (Exception $ex) {
+                    $content .= '<div class="stat_weekhvisitors">Missing data</div>';
                 }
                 
             }
@@ -242,6 +244,7 @@ class serendipity_plugin_statistics extends serendipity_plugin
                         $content .= '<div class="stat_dayhvisitors">' . sprintf($this->get_config('text_dayvisitors'), '<span class="stat_number">' . $res['dayvisitors'] . '</span>') . "</div>\n";
                     }
                 } catch (Exception $ex) {
+                    $content .= '<div class="stat_dayhvisitors">Missing data</div>';
                 }
             }
 
@@ -268,6 +271,7 @@ class serendipity_plugin_statistics extends serendipity_plugin
                         $content .= '<div class="stat_currentvisitors">' . sprintf($this->get_config('text_currentvisitors'), '<span class="stat_number">' . $res['currentvisitors'] . '</span>') . "</div>\n";
                     }
                 } catch (Exception $ex) {
+                    $content .= '<div class="stat_currentvisitors">Missing data</div>';
                 }
             }
 


### PR DESCRIPTION
The database tables from serendipity_event_statistics can not be there and the sidebar plugin be still installed. This lead to a fatal error with PHP 8.4, as reported https://board.s9y.org/viewtopic.php?p=10459386&sid=7ebc4212360e8d1091a961556efeba9a#p10459386. Catching the exception will avoid the fatal error.