### PR TITLE
Init schema.org markup plugin on Spartacus

### DIFF
--- a/serendipity_event_schema/ChangeLog
+++ b/serendipity_event_schema/ChangeLog
@@ -1,0 +1,11 @@
+0.2.3:
+    * Add Readme as documentation to the serendipity backend
+
+0.2.2:
+    * Fix json being invalid if review item name had quotes
+
+0.2.1:
+    * Fix warning in preview when using PHP 8
+
+0.2:
+    * Add option to set review schema markup in combination with the extended property plugin

--- a/serendipity_event_schema/README
+++ b/serendipity_event_schema/README
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>README</title>
+  <style>
+    html {
+      color: #1a1a1a;
+      background-color: #fdfdfd;
+    }
+    body {
+      margin: 0 auto;
+      max-width: 36em;
+      padding-left: 50px;
+      padding-right: 50px;
+      padding-top: 50px;
+      padding-bottom: 50px;
+      hyphens: auto;
+      overflow-wrap: break-word;
+      text-rendering: optimizeLegibility;
+      font-kerning: normal;
+    }
+    @media (max-width: 600px) {
+      body {
+        font-size: 0.9em;
+        padding: 12px;
+      }
+      h1 {
+        font-size: 1.8em;
+      }
+    }
+    @media print {
+      html {
+        background-color: white;
+      }
+      body {
+        background-color: transparent;
+        color: black;
+        font-size: 12pt;
+      }
+      p, h2, h3 {
+        orphans: 3;
+        widows: 3;
+      }
+      h2, h3, h4 {
+        page-break-after: avoid;
+      }
+    }
+    p {
+      margin: 1em 0;
+    }
+    a {
+      color: #1a1a1a;
+    }
+    a:visited {
+      color: #1a1a1a;
+    }
+    img {
+      max-width: 100%;
+    }
+    svg {
+      height: auto;
+      max-width: 100%;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.4em;
+    }
+    h5, h6 {
+      font-size: 1em;
+      font-style: italic;
+    }
+    h6 {
+      font-weight: normal;
+    }
+    ol, ul {
+      padding-left: 1.7em;
+      margin-top: 1em;
+    }
+    li > ol, li > ul {
+      margin-top: 0;
+    }
+    blockquote {
+      margin: 1em 0 1em 1.7em;
+      padding-left: 1em;
+      border-left: 2px solid #e6e6e6;
+      color: #606060;
+    }
+    code {
+      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
+      font-size: 85%;
+      margin: 0;
+      hyphens: manual;
+    }
+    pre {
+      margin: 1em 0;
+      overflow: auto;
+    }
+    pre code {
+      padding: 0;
+      overflow: visible;
+      overflow-wrap: normal;
+    }
+    .sourceCode {
+     background-color: transparent;
+     overflow: visible;
+    }
+    hr {
+      background-color: #1a1a1a;
+      border: none;
+      height: 1px;
+      margin: 1em 0;
+    }
+    table {
+      margin: 1em 0;
+      border-collapse: collapse;
+      width: 100%;
+      overflow-x: auto;
+      display: block;
+      font-variant-numeric: lining-nums tabular-nums;
+    }
+    table caption {
+      margin-bottom: 0.75em;
+    }
+    tbody {
+      margin-top: 0.5em;
+      border-top: 1px solid #1a1a1a;
+      border-bottom: 1px solid #1a1a1a;
+    }
+    th {
+      border-top: 1px solid #1a1a1a;
+      padding: 0.25em 0.5em 0.25em 0.5em;
+    }
+    td {
+      padding: 0.125em 0.5em 0.25em 0.5em;
+    }
+    header {
+      margin-bottom: 4em;
+      text-align: center;
+    }
+    #TOC li {
+      list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
+    }
+    #TOC a:not(:hover) {
+      text-decoration: none;
+    }
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  </style>
+</head>
+<body>
+<h1 id="serendipity_event_schema">serendipity_event_schema</h1>
+<p>This plugin will automatically set the necessary schema.org markup to
+describe a blog article as blog article.</p>
+<p>In its configuration you can set the custom markup that describes
+your organization. The default value is fitting for a single blog
+author.</p>
+<p>If used in combination with the extended properties plugin you can
+use this plugin to output schema.org markup that</p>
+<ol type="1">
+<li>Describes the topic of the article</li>
+<li>Reviews the article</li>
+</ol>
+<p>Those are markups Google likes to use for its rich search results
+display.</p>
+<h2 id="review-configuration">Review Configuration</h2>
+<p>In the extended properties, add those 4 custom fields:</p>
+<pre><code>schemaType,
+schemaName,
+schemaBrandName,
+schemaRating</code></pre>
+<p>Then, when writing an article, fill those 4 fields in the entry
+editor with values. Fitting values are:</p>
+<ul>
+<li><strong>schemaType</strong>: <code>Product</code>,
+<code>Movie</code> - possible more, but test it with the <a
+href="https://search.google.com/test/rich-results">rich result
+tester</a></li>
+<li><strong>schemaName</strong>: The thing you are writing about,
+e.g. <em>iPhone 42</em>.</li>
+<li><strong>schemaBrandName</strong>: The brand name of the producer,
+e.g. <em>Apple</em></li>
+<li><strong>schemaRating</strong>: 0-5, e.g. <em>4.0</em></li>
+</ul>
+<p>See <a
+href="https://developers.google.com/search/docs/data-types/review-snippet">Google’s
+documentation</a> about what can be reviewed and for example markup.</p>
+</body>
+</html>

--- a/serendipity_event_schema/README.md
+++ b/serendipity_event_schema/README.md
@@ -1,0 +1,33 @@
+# serendipity_event_schema
+
+This plugin will automatically set the necessary schema.org markup to describe a blog article as blog article.
+
+In its configuration you can set the custom markup that describes your organization. The default value is fitting for a single blog author.
+
+If used in combination with the extended properties plugin you can use this plugin to output schema.org markup that
+
+ 1. Describes the topic of the article
+ 2. Reviews the article
+
+Those are markups Google likes to use for its rich search results display.
+
+## Review Configuration
+
+In the extended properties, add those 4 custom fields:
+
+```
+schemaType,
+schemaName,
+schemaBrandName,
+schemaRating
+```
+
+Then, when writing an article, fill those 4 fields in the entry editor with values. Fitting values are:
+
+ * **schemaType**: `Product`, `Movie` - possible more, but test it with the [rich result tester](https://search.google.com/test/rich-results)
+ * **schemaName**: The thing you are writing about, e.g. *iPhone 42*.
+ * **schemaBrandName**: The brand name of the producer, e.g. *Apple*
+ * **schemaRating**: 0-5, e.g. *4.0*
+
+
+ See [Google's documentation](https://developers.google.com/search/docs/data-types/review-snippet) about what can be reviewed and for example markup.

--- a/serendipity_event_schema/lang_en.inc.php
+++ b/serendipity_event_schema/lang_en.inc.php
@@ -1,0 +1,8 @@
+<?php #
+
+@define('PLUGIN_EVENT_SCHEMA_NAME', 'Schema.org Markup');
+@define('PLUGIN_EVENT_SCHEMA_DESC', 'Add schema.org markup to entries to enable rich result display on Google.');
+@define('PLUGIN_EVENT_SCHEMA_IMAGE', 'Fallback Image');
+@define('PLUGIN_EVENT_SCHEMA_IMAGE_DESC', 'Image shown if the entry contains no own image. Set to "none" to deacivate.');
+@define('PLUGIN_EVENT_SCHEMA_PUBLISHER', 'Publisher');
+@define('PLUGIN_EVENT_SCHEMA_PUBLISHER_DESC', 'Publisher metadata. This is required by Google, see <a href="https://schema.org/CreativeWork">the schema.org doc</a> for an example.');

--- a/serendipity_event_schema/serendipity_event_schema.php
+++ b/serendipity_event_schema/serendipity_event_schema.php
@@ -1,0 +1,174 @@
+<?php
+
+if (IN_serendipity !== true) {
+    die ("Don't hack!");
+}
+
+@serendipity_plugin_api::load_language(dirname(__FILE__));
+
+class serendipity_event_schema extends serendipity_event {
+    var $title = PLUGIN_EVENT_SCHEMA_NAME;
+
+    function introspect(&$propbag) {
+        global $serendipity;
+
+        $propbag->add('name',          PLUGIN_EVENT_SCHEMA_NAME);
+        $propbag->add('description',   PLUGIN_EVENT_SCHEMA_DESC);
+        $propbag->add('stackable',     false);
+        $propbag->add('author',        'Malte Paskuda');
+        $propbag->add('version',       '0.2.2');
+        $propbag->add('requirements',  array(
+            'serendipity' => '2.0'
+        ));
+        $propbag->add('event_hooks',   array('frontend_display:html:per_entry' => true));
+        $propbag->add('groups', array('FRONTEND_ENTRY_RELATED'));
+
+        $propbag->add('configuration', array('article_image', 'publisher'));
+
+    }
+
+    function generate_content(&$title) {
+        $title = $this->title;
+    }
+
+
+    function introspect_config_item($name, &$propbag) {
+        global $serendipity;
+        switch($name) {
+            case 'article_image':
+                $propbag->add('type',           'media');
+                $propbag->add('name',           PLUGIN_EVENT_SCHEMA_IMAGE);
+                $propbag->add('description',    PLUGIN_EVENT_SCHEMA_IMAGE_DESC);
+                $propbag->add('default',        '');
+                break;
+
+            case 'publisher':
+                $propbag->add('type',           'text');
+                $propbag->add('name',           PLUGIN_EVENT_SCHEMA_PUBLISHER);
+                $propbag->add('description',    PLUGIN_EVENT_SCHEMA_PUBLISHER_DESC);
+                $propbag->add('default',        '"publisher": {
+    "@type": "Organization",
+    "name": "' . $serendipity['realname'] . '",
+    "logo": {
+        "@type": "ImageObject",
+        "width": 60,
+        "height": 60,
+        "url": "' . $serendipity['baseURL'] . 'favicon.png' . '"
+    }
+  }');
+                break;
+
+        }
+        return true;
+    }
+
+    function event_hook($event, &$bag, &$eventData, $addData = null) {
+        global $serendipity;
+
+        $hooks = &$bag->get('event_hooks');
+
+        if (isset($hooks[$event])) {
+            switch($event) {
+                case 'frontend_display:html:per_entry':
+                    if ($serendipity['view'] ?? '' == 'entry') {
+                        $article_image = $this->get_config('article_image', '');
+                        if (isset($eventData['properties']) && isset($eventData['properties']['entry_image'])) {
+                            // if entry_image is set, use this image instead (first priority)
+                            $article_image = $eventData['properties']['entry_image'];
+                        } else if (isset($eventData['properties']) && isset($eventData['properties']['timeline_image'])) {
+                            // if timeline_image from timeline theme is set, use this image (second priority)
+                            $article_image = $eventData['properties']['timeline_image'];
+                        } else if (isset($eventData['properties']) && isset($eventData['properties']['ep_featuredImage'])) {
+                            // if ep_featuredImage from photo theme is set, use this image (third priority)
+                            $article_image = $eventData['properties']['ep_featuredImage'];
+                        } else {
+                            // Fourth priority:
+                            // This is searching for the first image in an entry to use as facebook article image.
+                            // A better approach would be to register in the entry editor when an image was added
+                            if (preg_match_all('@<img.*src=["\'](.+)["\']@imsU', $eventData['body'] . $eventData['extended'], $images)) {
+                                foreach ($images[1] as $im) {
+                                    if (strpos($im, '/emoticons/') === false) {
+                                        $article_image = $im;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        $blogURL = 'http' . ($_SERVER['HTTPS'] ? 's' : '') . '://' . $_SERVER['HTTP_HOST'];
+                        $publisher = $this->get_config('publisher', '"publisher": {
+                                "@type": "Organization",
+                                "name": "' . $eventData['author'] . '",
+                                "logo": {
+                                    "@type": "ImageObject",
+                                    "width": 60,
+                                    "height": 60,
+                                    "url": "' . $blogURL . '/favicon.png' . '"
+                                }
+                              }');
+
+                        $eventData['display_dat'] .= '<script type="application/ld+json">
+                            {
+                              "@context": "https://schema.org",
+                              "@type": "BlogPosting",
+                              "mainEntityOfPage": {
+                                "@type": "WebPage",
+                                "@id": "' . $eventData['rdf_ident'] . '"
+                              },
+                              "headline": "' . $eventData['title'] . '",
+                              ' . ($article_image ? "\"image\":  \"{$article_image}\"," : '') . '
+                              "datePublished": "' . date(DATE_ISO8601, $eventData['timestamp'] ) . '",
+                              "dateModified": "' . date(DATE_ISO8601, $eventData['last_modified']) . '",
+                              "author": {
+                                "@type": "Person",
+                                "name": "' . $eventData['author'] . '"
+                              },
+                              ' . $publisher .' 
+                            }
+                            </script>';
+
+                        if (isset($eventData['properties']) && isset($eventData['properties']['ep_schemaType'])
+                                                            && isset($eventData['properties']['ep_schemaName'])
+                                                            && isset($eventData['properties']['ep_schemaBrandName'])
+                                                            && isset($eventData['properties']['ep_schemaRating'])
+                                                
+                        ) {
+                            $eventData['display_dat'] .= '<script type="application/ld+json">      
+                                      {"@context": "http://schema.org",
+                                    "@type": "' . $eventData['properties']['ep_schemaType'] . '",
+                                    "name": "' . htmlspecialchars($eventData['properties']['ep_schemaName']) . '",
+                                    ' . ($article_image ? "\"image\":  [ \"{$article_image}\" ]," : '') . '
+                                    "description": "",
+                                    "brand": {
+                                        "@type": "Thing",
+                                        "name": "' . $eventData['properties']['ep_schemaBrandName'] . '"
+                                    },
+                                    "review": {
+                                        "@type": "Review",
+                                        "author": {
+                                            "@type": "Person",
+                                            "name": "' . $eventData['author'] . '"
+                                        },
+                                        "datePublished": "' . date(DATE_ISO8601, $eventData['timestamp'] ) . '",
+                                        "reviewRating": {
+                                            "@type": "Rating",
+                                            "ratingValue": "' . $eventData['properties']['ep_schemaRating'] . '"
+                                        }
+                                    }
+                                }
+                                </script>'; 
+                        }
+                    }
+                    break;
+
+                default:
+                    return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
+}
+
+/* vim: set sts=4 ts=4 expandtab : */
+?>


### PR DESCRIPTION
Moved over from https://github.com/onli/serendipity_event_schema. 

This plugin adds the schema.org markup to identify blog entries as such and sets (configurable) author information. It also integrates with the entryproperties plugin to provide the option of including review markup. The plugin has been used for years on https://www.onli-blogging.de and has seen usage in other blogs. It is also already tested that search engines - specifically google - do indeed accept the produced markup.